### PR TITLE
[improve][fn] Run search connectors in parallel

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -56,6 +56,7 @@ This change added tests and can be verified as follows:
 - [ ] The public API
 - [ ] The schema
 - [ ] The default values of configurations
+- [ ] The threading model
 - [ ] The binary protocol
 - [ ] The REST endpoints
 - [ ] The admin CLI options

--- a/.github/workflows/ci-go-functions.yaml
+++ b/.github/workflows/ci-go-functions.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Check changed files
         id: check_changes
         run: |
-          echo "::set-output name=docs_only::${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.docs_count) && fromJSON(steps.changes.outputs.docs_count) > 0 }}"
+          echo "docs_only=${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.docs_count) && fromJSON(steps.changes.outputs.docs_count) > 0 }}" >> $GITHUB_OUTPUT
 
       - name: Check if the PR has been approved for testing
         if: ${{ steps.check_changes.outputs.docs_only != 'true' && github.repository == 'apache/pulsar' && github.event_name == 'pull_request' }}

--- a/.github/workflows/pulsar-ci-flaky.yaml
+++ b/.github/workflows/pulsar-ci-flaky.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Check changed files
         id: check_changes
         run: |
-          echo "::set-output name=docs_only::${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.docs_count) && fromJSON(steps.changes.outputs.docs_count) > 0 }}"
+          echo "docs_only=${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.docs_count) && fromJSON(steps.changes.outputs.docs_count) > 0 }}" >> $GITHUB_OUTPUT
 
       - name: Check if the PR has been approved for testing
         if: ${{ steps.check_changes.outputs.docs_only != 'true' && github.repository == 'apache/pulsar' && github.event_name == 'pull_request' }}

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Check changed files
         id: check_changes
         run: |
-          echo "::set-output name=docs_only::${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.docs_count) && fromJSON(steps.changes.outputs.docs_count) > 0 }}"
+          echo "docs_only=${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.docs_count) && fromJSON(steps.changes.outputs.docs_count) > 0 }}" >> $GITHUB_OUTPUT
 
 
       - name: Check if the PR has been approved for testing

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ components in the Pulsar ecosystem, including connectors, adapters, and other la
 
 ### Clients
 
+- [C++ Client](https://github.com/apache/pulsar-client-cpp)
+- [Python Client](https://github.com/apache/pulsar-client-python)
 - [.NET/C# Client](https://github.com/apache/pulsar-dotpulsar)
 - [Go Client](https://github.com/apache/pulsar-client-go)
 - [NodeJS Client](https://github.com/apache/pulsar-client-node)

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1014,6 +1014,8 @@ bookkeeperClientMinAvailableBookiesInIsolationGroups=
 # Enable/disable having read operations for a ledger to be sticky to a single bookie.
 # If this flag is enabled, the client will use one single bookie (by preference) to read
 # all entries for a ledger.
+# Please notice that enabling sticky reads also requires that the ensemble size equals write quorum size for the ledger's
+# persistence policies.
 bookkeeperEnableStickyReads=true
 
 # Set the client security provider factory class name.
@@ -1059,13 +1061,15 @@ bookkeeperExplicitLacIntervalInMills=0
 
 ### --- Managed Ledger --- ###
 
-# Number of bookies to use when creating a ledger
+# Ensemble size (E), Number of bookies to use for storing entries in a ledger.
+# Please notice that sticky reads enabled by bookkeeperEnableStickyReads=true aren’t used
+# unless ensemble size (E) equals write quorum (Qw) size.
 managedLedgerDefaultEnsembleSize=2
 
-# Number of copies to store for each message
+# Write quorum (Qw) size, Replication factor for storing entries (messages) in a ledger.
 managedLedgerDefaultWriteQuorum=2
 
-# Number of guaranteed copies (acks to wait before write is complete)
+# Ack quorum (Qa) size, Number of guaranteed copies (acks to wait for before a write is considered completed)
 managedLedgerDefaultAckQuorum=2
 
 # with OpportunisticStriping=true the ensembleSize is adapted automatically to writeQuorum

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -284,7 +284,7 @@ The Apache Software License, Version 2.0
     - org.apache.commons-commons-collections4-4.4.jar
     - org.apache.commons-commons-compress-1.21.jar
     - org.apache.commons-commons-lang3-3.11.jar
-    - org.apache.commons-commons-text-1.9.jar
+    - org.apache.commons-commons-text-1.10.0.jar
  * Netty
     - io.netty-netty-buffer-4.1.77.Final.jar
     - io.netty-netty-codec-4.1.77.Final.jar

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -2188,11 +2188,12 @@ public class ManagedCursorImpl implements ManagedCursor {
                             individualDeletedMessages);
                     }
                 } else if (config.isDeletionAtBatchIndexLevelEnabled() && batchDeletedIndexes != null) {
-                    BitSetRecyclable bitSet = batchDeletedIndexes.computeIfAbsent(position, (v) ->
-                        BitSetRecyclable.create().resetWords(position.ackSet));
                     BitSetRecyclable givenBitSet = BitSetRecyclable.create().resetWords(position.ackSet);
-                    bitSet.and(givenBitSet);
-                    givenBitSet.recycle();
+                    BitSetRecyclable bitSet = batchDeletedIndexes.computeIfAbsent(position, (v) -> givenBitSet);
+                    if (givenBitSet != bitSet) {
+                        bitSet.and(givenBitSet);
+                        givenBitSet.recycle();
+                    }
                     if (bitSet.isEmpty()) {
                         PositionImpl previousPosition = ledger.getPreviousPosition(position);
                         individualDeletedMessages.addOpenClosed(previousPosition.getLedgerId(),

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerBkTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerBkTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.bookkeeper.mledger.impl;
 
+import static org.apache.pulsar.common.util.PortManager.releaseLockedPort;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
@@ -117,7 +118,7 @@ public class ManagedLedgerBkTest extends BookKeeperClusterTestCase {
         metadataStore.unsetAlwaysFail();
 
         bkc = new BookKeeperTestClient(baseClientConf);
-        startNewBookie();
+        int port = startNewBookie();
 
         // Reconnect a new bk client
         factory.shutdown();
@@ -147,6 +148,7 @@ public class ManagedLedgerBkTest extends BookKeeperClusterTestCase {
         assertEquals("entry-2", new String(entries.get(0).getData()));
         entries.forEach(Entry::release);
         factory.shutdown();
+        releaseLockedPort(port);
     }
 
     @Test

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -2478,6 +2478,23 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         log.info("Target position is {}", targetPosition);
         assertEquals(targetPosition.getLedgerId(), secondLedger);
         assertEquals(targetPosition.getEntryId(), 4);
+
+        // test for n > NumberOfEntriesInStorage
+        searchPosition = new PositionImpl(secondLedger, 0);
+        targetPosition = managedLedger.getPositionAfterN(searchPosition, 100, ManagedLedgerImpl.PositionBound.startIncluded);
+        assertEquals(targetPosition.getLedgerId(), secondLedger);
+        assertEquals(targetPosition.getEntryId(), 4);
+
+        // test for startPosition > current ledger
+        searchPosition = new PositionImpl(999, 0);
+        targetPosition = managedLedger.getPositionAfterN(searchPosition, 0, ManagedLedgerImpl.PositionBound.startIncluded);
+        assertEquals(targetPosition.getLedgerId(), secondLedger);
+        assertEquals(targetPosition.getEntryId(), 4);
+
+        searchPosition = new PositionImpl(999, 0);
+        targetPosition = managedLedger.getPositionAfterN(searchPosition, 10, ManagedLedgerImpl.PositionBound.startExcluded);
+        assertEquals(targetPosition.getLedgerId(), secondLedger);
+        assertEquals(targetPosition.getEntryId(), 4);
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@ flexible messaging model and an intuitive client API.</description>
     <bookkeeper.version>4.15.1</bookkeeper.version>
     <zookeeper.version>3.8.0</zookeeper.version>
     <commons-cli.version>1.5.0</commons-cli.version>
-    <commons-text.version>1.9</commons-text.version>
+    <commons-text.version>1.10.0</commons-text.version>
     <snappy.version>1.1.8.4</snappy.version> <!-- ZooKeeper server -->
     <dropwizardmetrics.version>4.1.12.1</dropwizardmetrics.version> <!-- ZooKeeper server -->
     <curator.version>5.1.0</curator.version>

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1785,19 +1785,22 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @FieldContext(
         minValue = 1,
         category = CATEGORY_STORAGE_ML,
-        doc = "Number of bookies to use when creating a ledger"
+        doc = "Ensemble (E) size, Number of bookies to use for storing entries in a ledger.\n"
+            + "Please notice that sticky reads enabled by bookkeeperEnableStickyReads=true aren’t used "
+            + " unless ensemble size (E) equals write quorum (Qw) size."
     )
     private int managedLedgerDefaultEnsembleSize = 2;
     @FieldContext(
         minValue = 1,
         category = CATEGORY_STORAGE_ML,
-        doc = "Number of copies to store for each message"
+        doc = "Write quorum (Qw) size, Replication factor for storing entries (messages) in a ledger."
     )
     private int managedLedgerDefaultWriteQuorum = 2;
     @FieldContext(
         minValue = 1,
         category = CATEGORY_STORAGE_ML,
-        doc = "Number of guaranteed copies (acks to wait before write is complete)"
+        doc = "Ack quorum (Qa) size, Number of guaranteed copies "
+               + "(acks to wait for before a write is considered completed)"
     )
     private int managedLedgerDefaultAckQuorum = 2;
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -4524,7 +4524,7 @@ public class PersistentTopicsBase extends AdminResource {
                 });
 
                 FutureUtil.waitForAll(subscriptionFutures).thenRun(() -> {
-                    log.info("[{}] Successfully created new partitions {}", clientAppId(), topicName);
+                    log.info("[{}] Successfully created subscriptions on new partitions {}", clientAppId(), topicName);
                     result.complete(null);
                 }).exceptionally(ex -> {
                     log.warn("[{}] Failed to create subscriptions on new partitions for {}",

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTracker.java
@@ -33,7 +33,7 @@ import org.apache.pulsar.common.util.collections.TripleLongPriorityQueue;
 @Slf4j
 public class InMemoryDelayedDeliveryTracker implements DelayedDeliveryTracker, TimerTask {
 
-    private final TripleLongPriorityQueue priorityQueue = new TripleLongPriorityQueue();
+    protected final TripleLongPriorityQueue priorityQueue = new TripleLongPriorityQueue();
 
     private final PersistentDispatcherMultipleConsumers dispatcher;
 
@@ -41,7 +41,7 @@ public class InMemoryDelayedDeliveryTracker implements DelayedDeliveryTracker, T
     private final Timer timer;
 
     // Current timeout or null if not set
-    private Timeout timeout;
+    protected Timeout timeout;
 
     // Timestamp at which the timeout is currently set
     private long currentTimeoutTarget;
@@ -265,7 +265,7 @@ public class InMemoryDelayedDeliveryTracker implements DelayedDeliveryTracker, T
         if (log.isDebugEnabled()) {
             log.debug("[{}] Timer triggered", dispatcher.getName());
         }
-        if (timeout.isCancelled()) {
+        if (timeout == null || timeout.isCancelled()) {
             return;
         }
 
@@ -279,10 +279,11 @@ public class InMemoryDelayedDeliveryTracker implements DelayedDeliveryTracker, T
 
     @Override
     public void close() {
-        priorityQueue.close();
         if (timeout != null) {
             timeout.cancel();
+            timeout = null;
         }
+        priorityQueue.close();
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1595,7 +1595,8 @@ public class BrokerService implements Closeable {
                     RetentionPolicies retentionPolicies = null;
                     OffloadPoliciesImpl topicLevelOffloadPolicies = null;
 
-                    if (pulsar.getConfig().isTopicLevelPoliciesEnabled()) {
+                    if (pulsar.getConfig().isTopicLevelPoliciesEnabled()
+                            && !NamespaceService.isSystemServiceNamespace(namespace.toString())) {
                         try {
                             TopicPolicies topicPolicies = pulsar.getTopicPoliciesService().getTopicPolicies(topicName);
                             if (topicPolicies != null) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -101,6 +101,10 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
 
     private CompletableFuture<Void> sendTopicPolicyEvent(TopicName topicName, ActionType actionType,
                                                          TopicPolicies policies) {
+        if (NamespaceService.isHeartbeatNamespace(topicName.getNamespaceObject())) {
+            return CompletableFuture.failedFuture(
+                    new BrokerServiceException.NotAllowedException("Not allowed to send event to health check topic"));
+        }
         CompletableFuture<Void> result = new CompletableFuture<>();
         try {
             createSystemTopicFactoryIfNeeded();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicImpl.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.compaction;
 import static org.apache.pulsar.common.protocol.Commands.DEFAULT_CONSUMER_EPOCH;
 import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ComparisonChain;
 import io.netty.buffer.ByteBuf;
 import java.util.ArrayList;
@@ -164,7 +165,8 @@ public class CompactedTopicImpl implements CompactedTopic {
         return promise;
     }
 
-    private static void findStartPointLoop(PositionImpl p, long start, long end,
+    @VisibleForTesting
+    static void findStartPointLoop(PositionImpl p, long start, long end,
                                            CompletableFuture<Long> promise,
                                            AsyncLoadingCache<Long, MessageIdData> cache) {
         long midpoint = start + ((end - start) / 2);
@@ -178,7 +180,7 @@ public class CompactedTopicImpl implements CompactedTopic {
                     if (comparePositionAndMessageId(p, startEntry.join()) <= 0) {
                         promise.complete(start);
                     } else if (comparePositionAndMessageId(p, middleEntry.join()) <= 0) {
-                        findStartPointLoop(p, start, midpoint, promise, cache);
+                        findStartPointLoop(p, start + 1, midpoint, promise, cache);
                     } else if (comparePositionAndMessageId(p, endEntry.join()) <= 0) {
                         findStartPointLoop(p, midpoint + 1, end, promise, cache);
                     } else {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/MultiBrokerBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/MultiBrokerBaseTest.java
@@ -21,12 +21,14 @@ package org.apache.pulsar.broker;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminBuilder;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.common.util.PortManager;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 import org.apache.pulsar.metadata.impl.ZKMetadataStore;
@@ -124,6 +126,9 @@ public abstract class MultiBrokerBaseTest extends MockedPulsarServiceBaseTest {
                 try {
                     pulsarService.getConfiguration().setBrokerShutdownTimeoutMs(0L);
                     pulsarService.close();
+                    pulsarService.getConfiguration().getBrokerServicePort().ifPresent(PortManager::releaseLockedPort);
+                    pulsarService.getConfiguration().getWebServicePort().ifPresent(PortManager::releaseLockedPort);
+                    pulsarService.getConfiguration().getWebServicePortTls().ifPresent(PortManager::releaseLockedPort);
                 } catch (PulsarServerException e) {
                     // ignore
                 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -558,7 +558,7 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
      * @param namespaceName
      * @throws Exception
      */
-    @Test(dataProvider = "namespaceNames", timeOut = 10000)
+    @Test(dataProvider = "namespaceNames", timeOut = 30000)
     public void testResetCursorOnPosition(String namespaceName) throws Exception {
         final String topicName = "persistent://prop-xyz/use/" + namespaceName + "/resetPosition";
         final int totalProducedMessages = 50;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -164,7 +164,8 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         pulsar.getConfiguration().setForceDeleteNamespaceAllowed(true);
         for (String tenant : admin.tenants().getTenants()) {
             for (String namespace : admin.namespaces().getNamespaces(tenant)) {
-                deleteNamespaceGraceFully(namespace, true);
+                deleteNamespaceGraceFullyByMultiPulsars(namespace, true, admin, pulsar,
+                        mockPulsarSetup.getPulsar());
             }
             admin.tenants().deleteTenant(tenant, true);
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -63,6 +63,7 @@ import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.intercept.CounterBrokerInterceptor;
 import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.service.BrokerTestBase;
+import org.apache.pulsar.broker.service.CanPausedNamespaceService;
 import org.apache.pulsar.broker.service.PulsarMetadataEventSynchronizer;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminBuilder;
@@ -382,7 +383,8 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
         doReturn(configSynchronizer != null ? createConfigurationMetadataStore(configSynchronizer)
                 : createConfigurationMetadataStore()).when(pulsar).createConfigurationMetadataStore(any());
 
-        Supplier<NamespaceService> namespaceServiceSupplier = () -> spyWithClassAndConstructorArgs(NamespaceService.class, pulsar);
+        Supplier<NamespaceService> namespaceServiceSupplier =
+                () -> spyWithClassAndConstructorArgs(CanPausedNamespaceService.class, pulsar);
         doReturn(namespaceServiceSupplier).when(pulsar).getNamespaceServiceProvider();
 
         doReturn(sameThreadOrderedSafeExecutor).when(pulsar).getOrderedExecutor();
@@ -667,19 +669,27 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
     }
 
     /**
-     * see {@link BrokerTestBase#deleteNamespaceGraceFully(String, boolean, PulsarService, PulsarAdmin)}
+     * see {@link BrokerTestBase#deleteNamespaceGraceFully(String, boolean, PulsarAdmin, Collection)}
      */
     protected void deleteNamespaceGraceFully(String ns, boolean force)
             throws Exception {
-        BrokerTestBase.deleteNamespaceGraceFully(ns, force, pulsar, admin);
+        BrokerTestBase.deleteNamespaceGraceFully(ns, force, admin, pulsar);
     }
 
     /**
-     * see {@link BrokerTestBase#deleteNamespaceGraceFully(String, boolean, PulsarService, PulsarAdmin)}
+     * see {@link BrokerTestBase#deleteNamespaceGraceFully(String, boolean, PulsarAdmin, Collection)}
      */
     protected void deleteNamespaceGraceFully(String ns, boolean force, PulsarAdmin admin)
             throws Exception {
-        BrokerTestBase.deleteNamespaceGraceFully(ns, force, pulsar, admin);
+        BrokerTestBase.deleteNamespaceGraceFully(ns, force, admin, pulsar);
+    }
+
+    /**
+     * see see {@link BrokerTestBase#deleteNamespaceGraceFully(String, boolean, PulsarAdmin, Collection)}
+     */
+    protected void deleteNamespaceGraceFullyByMultiPulsars(String ns, boolean force, PulsarAdmin admin,
+                                                           PulsarService...pulsars) throws Exception {
+        BrokerTestBase.deleteNamespaceGraceFully(ns, force, admin, pulsars);
     }
 
     private static final Logger log = LoggerFactory.getLogger(MockedPulsarServiceBaseTest.class);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -80,6 +80,7 @@ import org.apache.pulsar.metadata.impl.ZKMetadataStore;
 import org.apache.pulsar.tests.TestRetrySupport;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.MockZooKeeper;
+import org.apache.zookeeper.MockZooKeeperSession;
 import org.apache.zookeeper.data.ACL;
 import org.mockito.Mockito;
 import org.mockito.internal.util.MockUtil;
@@ -400,7 +401,7 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
     }
 
     protected MetadataStoreExtended createLocalMetadataStore() throws MetadataStoreException {
-        return new ZKMetadataStore(mockZooKeeper, MetadataStoreConfig.builder()
+        return new ZKMetadataStore(MockZooKeeperSession.newInstance(mockZooKeeper), MetadataStoreConfig.builder()
                 .metadataStoreName(MetadataStoreConfig.METADATA_STORE).build());
     }
 
@@ -413,7 +414,7 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
     }
 
     protected MetadataStoreExtended createConfigurationMetadataStore() throws MetadataStoreException {
-        return new ZKMetadataStore(mockZooKeeperGlobal, MetadataStoreConfig.builder()
+        return new ZKMetadataStore(MockZooKeeperSession.newInstance(mockZooKeeperGlobal), MetadataStoreConfig.builder()
                 .metadataStoreName(MetadataStoreConfig.CONFIGURATION_METADATA_STORE).build());
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/AdvertisedListenersTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/AdvertisedListenersTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.loadbalance;
 
+import static org.apache.pulsar.common.util.PortManager.nextLockedFreePort;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
@@ -25,7 +26,6 @@ import java.net.URI;
 import java.util.Optional;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.bookkeeper.util.PortManager;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -66,9 +66,9 @@ public class AdvertisedListenersTest extends MultiBrokerBaseTest {
     }
 
     private void updateConfig(ServiceConfiguration conf, String advertisedAddress) {
-        int pulsarPort = PortManager.nextFreePort();
-        int httpPort = PortManager.nextFreePort();
-        int httpsPort = PortManager.nextFreePort();
+        int pulsarPort = nextLockedFreePort();
+        int httpPort = nextLockedFreePort();
+        int httpsPort = nextLockedFreePort();
 
         // Use invalid domain name as identifier and instead make sure the advertised listeners work as intended
         conf.setAdvertisedAddress(advertisedAddress);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/OwnerShipForCurrentServerTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/OwnerShipForCurrentServerTestBase.java
@@ -45,6 +45,7 @@ import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.auth.SameThreadOrderedSafeExecutor;
 import org.apache.pulsar.broker.intercept.CounterBrokerInterceptor;
+import org.apache.pulsar.broker.service.CanPausedNamespaceService;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
@@ -131,7 +132,8 @@ public class OwnerShipForCurrentServerTestBase {
         MockZooKeeperSession mockZooKeeperSession = MockZooKeeperSession.newInstance(mockZooKeeper);
         doReturn(new ZKMetadataStore(mockZooKeeperSession)).when(pulsar).createLocalMetadataStore(null);
         doReturn(new ZKMetadataStore(mockZooKeeperSession)).when(pulsar).createConfigurationMetadataStore(null);
-        Supplier<NamespaceService> namespaceServiceSupplier = () -> spyWithClassAndConstructorArgs(NamespaceService.class, pulsar);
+        Supplier<NamespaceService> namespaceServiceSupplier = () -> spyWithClassAndConstructorArgs(
+                CanPausedNamespaceService.class, pulsar);
         doReturn(namespaceServiceSupplier).when(pulsar).getNamespaceServiceProvider();
 
         SameThreadOrderedSafeExecutor executor = new SameThreadOrderedSafeExecutor();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/protocol/SimpleProtocolHandlerTestsBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/protocol/SimpleProtocolHandlerTestsBase.java
@@ -22,12 +22,12 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.*;
 import io.netty.channel.socket.SocketChannel;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.bookkeeper.util.PortManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.BrokerTestBase;
+import org.apache.pulsar.common.util.PortManager;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -39,11 +39,14 @@ import java.net.Socket;
 import java.net.SocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
+import static org.apache.pulsar.common.util.PortManager.nextLockedFreePort;
 import static org.testng.Assert.assertEquals;
 
 @Slf4j
@@ -53,6 +56,8 @@ public abstract class SimpleProtocolHandlerTestsBase extends BrokerTestBase {
     public static final class MyProtocolHandler implements ProtocolHandler {
 
         private ServiceConfiguration conf;
+
+        private final List<Integer> ports = new ArrayList<>();
 
         @Override
         public String protocolName() {
@@ -81,7 +86,9 @@ public abstract class SimpleProtocolHandlerTestsBase extends BrokerTestBase {
 
         @Override
         public Map<InetSocketAddress, ChannelInitializer<SocketChannel>> newChannelInitializers() {
-            return Collections.singletonMap(new InetSocketAddress(conf.getBindAddress(), PortManager.nextFreePort()),
+            int port = nextLockedFreePort();
+            this.ports.add(port);
+            return Collections.singletonMap(new InetSocketAddress(conf.getBindAddress(), port),
                     new ChannelInitializer<SocketChannel>() {
                 @Override
                 protected void initChannel(SocketChannel socketChannel) throws Exception {
@@ -106,7 +113,7 @@ public abstract class SimpleProtocolHandlerTestsBase extends BrokerTestBase {
 
         @Override
         public void close() {
-
+            ports.removeIf(PortManager::releaseLockedPort);
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Sets;
 import java.net.URL;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
@@ -81,11 +82,27 @@ public class BacklogQuotaManagerTest {
     private static final int MAX_ENTRIES_PER_LEDGER = 5;
 
     /**
-     * see {@link BrokerTestBase#deleteNamespaceGraceFully(String, boolean, PulsarService, PulsarAdmin)}
+     * see {@link BrokerTestBase#deleteNamespaceGraceFully(String, boolean, PulsarAdmin, Collection)}
      */
     protected void deleteNamespaceGraceFully(String ns, boolean force)
             throws Exception {
-        BrokerTestBase.deleteNamespaceGraceFully(ns, force, pulsar, admin);
+        BrokerTestBase.deleteNamespaceGraceFully(ns, force, admin, pulsar);
+    }
+
+    /**
+     * see {@link BrokerTestBase#deleteNamespaceGraceFully(String, boolean, PulsarAdmin, Collection)}
+     */
+    protected void deleteNamespaceGraceFully(String ns, boolean force, PulsarAdmin admin)
+            throws Exception {
+        BrokerTestBase.deleteNamespaceGraceFully(ns, force, admin, pulsar);
+    }
+
+    /**
+     * see {@link BrokerTestBase#deleteNamespaceGraceFully(String, boolean, PulsarAdmin, Collection)}
+     */
+    protected void deleteNamespaceGraceFullyByMultiPulsars(String ns, boolean force, PulsarAdmin admin,
+                                                           PulsarService...pulsars) throws Exception {
+        BrokerTestBase.deleteNamespaceGraceFully(ns, force, admin, pulsars);
     }
 
     @DataProvider(name = "backlogQuotaSizeGB")

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/CanPausedNamespaceService.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/CanPausedNamespaceService.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import java.util.concurrent.locks.ReentrantLock;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.namespace.NamespaceService;
+import org.apache.pulsar.common.naming.NamespaceBundle;
+
+public class CanPausedNamespaceService extends NamespaceService {
+
+    private volatile boolean paused = false;
+
+    private ReentrantLock lock = new ReentrantLock();
+
+    public CanPausedNamespaceService(PulsarService pulsar) {
+        super(pulsar);
+    }
+
+    @Override
+    protected void onNamespaceBundleOwned(NamespaceBundle bundle) {
+        lock.lock();
+        try {
+            if (paused){
+                return;
+            }
+            super.onNamespaceBundleOwned(bundle);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void pause(){
+        lock.lock();
+        try {
+            paused = true;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void resume(){
+        lock.lock();
+        try {
+            paused = false;
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/NamespaceEventsSystemTopicServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/NamespaceEventsSystemTopicServiceTest.java
@@ -18,12 +18,15 @@
  */
 package org.apache.pulsar.broker.systopic;
 
+import static org.mockito.Mockito.mock;
 import com.google.common.collect.Sets;
 import java.util.HashSet;
 import lombok.Cleanup;
+import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.broker.service.persistent.SystemTopic;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
@@ -86,6 +89,16 @@ public class NamespaceEventsSystemTopicServiceTest extends MockedPulsarServiceBa
                 (PersistentTopic) pulsar.getBrokerService()
                         .getTopic(topicName, false)
                         .join().get();
+
+        Assert.assertEquals(SchemaCompatibilityStrategy.ALWAYS_COMPATIBLE, topic.getSchemaCompatibilityStrategy());
+    }
+
+    @Test
+    public void testSystemTopicSchemaCompatibility() throws Exception {
+        TopicPoliciesSystemTopicClient systemTopicClientForNamespace1 = systemTopicFactory
+                .createTopicPoliciesSystemTopicClient(NamespaceName.get(NAMESPACE1));
+        String topicName = systemTopicClientForNamespace1.getTopicName().toString();
+        SystemTopic topic = new SystemTopic(topicName, mock(ManagedLedger.class), pulsar.getBrokerService());
 
         Assert.assertEquals(SchemaCompatibilityStrategy.ALWAYS_COMPATIBLE, topic.getSchemaCompatibilityStrategy());
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.transaction;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.pulsar.common.naming.SystemTopicNames.PENDING_ACK_STORE_CURSOR_NAME;
 import static org.apache.pulsar.common.naming.SystemTopicNames.PENDING_ACK_STORE_SUFFIX;
 import static org.apache.pulsar.transaction.coordinator.impl.MLTransactionLogImpl.TRANSACTION_LOG_PREFIX;
 import static org.apache.pulsar.transaction.coordinator.impl.DisabledTxnLogBufferedWriterMetricsStats.DISABLED_BUFFERED_WRITER_METRICS;
@@ -406,20 +407,19 @@ public class TransactionTest extends TransactionTestBase {
         Transaction transaction = pulsarClient.newTransaction()
                 .build().get();
         TxnID txnID = transaction.getTxnID();
-        Assert.assertEquals(txnID.getLeastSigBits(), 0);
-        Assert.assertEquals(txnID.getMostSigBits(), 0);
+
         transaction.abort();
         transaction = pulsarClient.newTransaction()
                 .build().get();
-        txnID = transaction.getTxnID();
-        Assert.assertEquals(txnID.getLeastSigBits(), 1);
-        Assert.assertEquals(txnID.getMostSigBits(), 0);
+        TxnID txnID1 = transaction.getTxnID();
+        Assert.assertEquals(txnID1.getLeastSigBits(), txnID.getLeastSigBits() + 1);
+        Assert.assertEquals(txnID1.getMostSigBits(), 0);
     }
 
     @Test
     public void testSubscriptionRecreateTopic()
             throws PulsarAdminException, NoSuchFieldException, IllegalAccessException, PulsarClientException {
-        String topic = "persistent://pulsar/system/testReCreateTopic";
+        String topic = "persistent://pulsar/system/testSubscriptionRecreateTopic";
         String subName = "sub_testReCreateTopic";
         int retentionSizeInMbSetTo = 5;
         int retentionSizeInMbSetTopic = 6;
@@ -481,11 +481,7 @@ public class TransactionTest extends TransactionTestBase {
                         }
                 );
             });
-
-
         });
-
-
     }
 
     @Test
@@ -782,6 +778,8 @@ public class TransactionTest extends TransactionTestBase {
         Class<PulsarService> pulsarServiceClass = PulsarService.class;
         Field field = pulsarServiceClass.getDeclaredField("transactionPendingAckStoreProvider");
         field.setAccessible(true);
+        TransactionPendingAckStoreProvider originPendingAckStoreProvider =
+                (TransactionPendingAckStoreProvider) field.get(getPulsarServiceList().get(0));
         field.set(getPulsarServiceList().get(0), pendingAckStoreProvider);
 
         PendingAckHandleImpl pendingAckHandle1 = new PendingAckHandleImpl(persistentSubscription);
@@ -811,6 +809,7 @@ public class TransactionTest extends TransactionTestBase {
 
         // cleanup
         transactionTimer.stop();
+        field.set(getPulsarServiceList().get(0), originPendingAckStoreProvider);
     }
 
     @Test
@@ -1075,7 +1074,7 @@ public class TransactionTest extends TransactionTestBase {
     public void testPendingAckMarkDeletePosition() throws Exception {
         getPulsarServiceList().get(0).getConfig().setTransactionPendingAckLogIndexMinLag(1);
         getPulsarServiceList().get(0).getConfiguration().setManagedLedgerDefaultMarkDeleteRateLimit(5);
-        String topic = NAMESPACE1 + "/test1";
+        String topic = NAMESPACE1 + "/testPendingAckMarkDeletePosition";
 
         @Cleanup
         Producer<byte[]> producer = pulsarClient
@@ -1136,7 +1135,7 @@ public class TransactionTest extends TransactionTestBase {
                     .getPendingAckInternalStats(topic, "sub", false)
                     .pendingAckLogStats
                     .managedLedgerInternalStats;
-            String [] markDeletePosition = managedLedgerInternalStats.cursors.get("__pending_ack_state")
+            String [] markDeletePosition = managedLedgerInternalStats.cursors.get(PENDING_ACK_STORE_CURSOR_NAME)
                     .markDeletePosition.split(":");
             String [] lastConfirmedEntry = managedLedgerInternalStats.lastConfirmedEntry.split(":");
             Assert.assertEquals(markDeletePosition[0], lastConfirmedEntry[0]);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTestBase.java
@@ -27,6 +27,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import io.netty.channel.EventLoopGroup;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -48,6 +49,7 @@ import org.apache.pulsar.broker.auth.SameThreadOrderedSafeExecutor;
 import org.apache.pulsar.broker.intercept.CounterBrokerInterceptor;
 import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.service.BrokerTestBase;
+import org.apache.pulsar.broker.service.CanPausedNamespaceService;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.common.naming.NamespaceName;
@@ -195,7 +197,8 @@ public abstract class TransactionTestBase extends TestRetrySupport {
         MockZooKeeperSession mockZooKeeperSession = MockZooKeeperSession.newInstance(mockZooKeeper);
         doReturn(new ZKMetadataStore(mockZooKeeperSession)).when(pulsar).createLocalMetadataStore(null);
         doReturn(new ZKMetadataStore(mockZooKeeperSession)).when(pulsar).createConfigurationMetadataStore(null);
-        Supplier<NamespaceService> namespaceServiceSupplier = () -> spyWithClassAndConstructorArgs(NamespaceService.class, pulsar);
+        Supplier<NamespaceService> namespaceServiceSupplier =
+                () -> spyWithClassAndConstructorArgs(CanPausedNamespaceService.class, pulsar);
         doReturn(namespaceServiceSupplier).when(pulsar).getNamespaceServiceProvider();
 
         SameThreadOrderedSafeExecutor executor = new SameThreadOrderedSafeExecutor();
@@ -329,10 +332,26 @@ public abstract class TransactionTestBase extends TestRetrySupport {
     }
 
     /**
-     * see {@link BrokerTestBase#deleteNamespaceGraceFully(String, boolean, PulsarService, PulsarAdmin)}
+     * see {@link BrokerTestBase#deleteNamespaceGraceFully(String, boolean, PulsarAdmin, Collection)}
      */
     protected void deleteNamespaceGraceFully(String ns, boolean force)
             throws Exception {
-        BrokerTestBase.deleteNamespaceGraceFully(ns, force, pulsarServiceList.get(0), admin);
+        BrokerTestBase.deleteNamespaceGraceFully(ns, force, admin, pulsarServiceList);
+    }
+
+    /**
+     * see {@link BrokerTestBase#deleteNamespaceGraceFully(String, boolean, PulsarAdmin, Collection)}
+     */
+    protected void deleteNamespaceGraceFully(String ns, boolean force, PulsarAdmin admin)
+            throws Exception {
+        BrokerTestBase.deleteNamespaceGraceFully(ns, force, admin, pulsarServiceList);
+    }
+
+    /**
+     * see {@link BrokerTestBase#deleteNamespaceGraceFully(String, boolean, PulsarAdmin, Collection)}
+     */
+    protected void deleteNamespaceGraceFullyByMultiPulsars(String ns, boolean force, PulsarAdmin admin,
+                                                           Collection<PulsarService> pulsars) throws Exception {
+        BrokerTestBase.deleteNamespaceGraceFully(ns, force, admin, pulsars);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DispatcherBlockConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DispatcherBlockConsumerTest.java
@@ -50,6 +50,7 @@ import java.util.stream.Collectors;
 import lombok.Cleanup;
 import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.service.BrokerService;
+import org.apache.pulsar.broker.service.CanPausedNamespaceService;
 import org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.impl.ConsumerImpl;
@@ -633,7 +634,8 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
         // if broker unload bundle gracefully then cursor metadata recovered from zk else from ledger
         if (unloadBundleGracefully) {
             // set clean namespace which will not let broker unload bundle gracefully: stop broker
-            Supplier<NamespaceService> namespaceServiceSupplier = () -> spyWithClassAndConstructorArgs(NamespaceService.class, pulsar);
+            Supplier<NamespaceService> namespaceServiceSupplier =
+                    () -> spyWithClassAndConstructorArgs(CanPausedNamespaceService.class, pulsar);
             doReturn(namespaceServiceSupplier).when(pulsar).getNamespaceServiceProvider();
         }
         stopBroker();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
@@ -44,6 +44,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Cleanup;
@@ -63,8 +64,9 @@ import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -109,7 +111,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         };
     }
 
-    @BeforeMethod(alwaysRun = true)
+    @BeforeClass(alwaysRun = true)
     @Override
     protected void setup() throws Exception {
         super.internalSetup();
@@ -117,10 +119,20 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         this.conf.setSubscriptionKeySharedUseConsistentHashing(true);
     }
 
-    @AfterMethod(alwaysRun = true)
+    @AfterClass(alwaysRun = true)
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void resetDefaultNamespace() throws Exception {
+        List<String> list = admin.namespaces().getTopics("public/default");
+        for (String topicName : list){
+            if (!pulsar.getBrokerService().isSystemTopic(topicName)) {
+                admin.topics().delete(topicName, false);
+            }
+        }
     }
 
     private static final Random random = new Random(System.nanoTime());
@@ -441,12 +453,18 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
     public void testDisableKeySharedSubscription() throws PulsarClientException {
         this.conf.getSubscriptionTypesEnabled().remove("Key_Shared");
         String topic = "persistent://public/default/key_shared_disabled";
-        pulsarClient.newConsumer()
-            .topic(topic)
-            .subscriptionName("key_shared")
-            .subscriptionType(SubscriptionType.Key_Shared)
-            .ackTimeout(10, TimeUnit.SECONDS)
-            .subscribe();
+        try {
+            @Cleanup
+            Consumer c = pulsarClient.newConsumer()
+                    .topic(topic)
+                    .subscriptionName("key_shared")
+                    .subscriptionType(SubscriptionType.Key_Shared)
+                    .ackTimeout(10, TimeUnit.SECONDS)
+                    .subscribe();
+        } finally {
+            // reset subscription types.
+            this.conf.getSubscriptionTypesEnabled().add("Key_Shared");
+        }
     }
 
     @Test
@@ -481,6 +499,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         String slowKey = "slowKey";
 
         List<PulsarClient> clients = new ArrayList<>();
+        List<Consumer> consumers = new ArrayList<>();
         try {
             AtomicInteger receivedMessages = new AtomicInteger();
 
@@ -490,7 +509,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
                         .build();
                 clients.add(client);
 
-                client.newConsumer(Schema.INT32)
+                Consumer c = client.newConsumer(Schema.INT32)
                         .topic(topic)
                         .subscriptionName("key_shared")
                         .subscriptionType(SubscriptionType.Key_Shared)
@@ -509,6 +528,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
                             }
                         })
                         .subscribe();
+                consumers.add(c);
             }
 
             @Cleanup
@@ -535,6 +555,10 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
             Awaitility.await().untilAsserted(() -> {
                 assertEquals((double) receivedMessages.get(), N * 0.9, N * 0.3);
             });
+
+            for (Consumer c : consumers) {
+                c.close();
+            }
         } finally {
             for (PulsarClient c : clients) {
                 c.close();
@@ -1108,6 +1132,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
                 .subscriptionType(SubscriptionType.Key_Shared);
 
         // Create 3 consumers with same name
+        @Cleanup
         Consumer<String> c1 = cb.subscribe();
 
         @Cleanup
@@ -1115,6 +1140,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         @Cleanup
         Consumer<String> c3 = cb.subscribe();
 
+        @Cleanup
         Producer<String> p = pulsarClient.newProducer(Schema.STRING)
                 .topic(topicName)
                 .create();
@@ -1398,7 +1424,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
     }
 
     @Test
-    public void testStickyKeyRangesRestartConsumers() throws PulsarClientException, InterruptedException {
+    public void testStickyKeyRangesRestartConsumers() throws Exception {
         final String topic = TopicName.get("persistent", "public", "default",
                 "testStickyKeyRangesRestartConsumers" + UUID.randomUUID()).toString();
 
@@ -1411,6 +1437,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         CountDownLatch count1 = new CountDownLatch(2);
         CountDownLatch count2 = new CountDownLatch(13); // consumer 2 usually receive the fix messages
         CountDownLatch count3 = new CountDownLatch(numMessages);
+        @Cleanup
         Consumer<String> consumer1 = pulsarClient.newConsumer(
                         Schema.STRING)
                 .topic(topic)
@@ -1431,6 +1458,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
                 })
                 .subscribe();
 
+        @Cleanup
         Consumer<String> consumer2 = pulsarClient.newConsumer(
                         Schema.STRING)
                 .topic(topic)
@@ -1451,13 +1479,13 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
                 })
                 .subscribe();
 
-        pulsar.getExecutor().submit(() -> {
+        Future producerFuture = pulsar.getExecutor().submit(() -> {
             try
             {
                 try (Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
                         .topic(topic)
                         .enableBatching(false)
-                        .create();) {
+                        .create()) {
                     for (int i = 0; i < numMessages; i++)
                     {
                         String key = "test" + i;
@@ -1484,8 +1512,8 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         Thread.sleep(3000);
 
         // start consuming again...
-
-        pulsarClient.newConsumer(Schema.STRING)
+        @Cleanup
+        Consumer consumer3 = pulsarClient.newConsumer(Schema.STRING)
                 .topic(topic)
                 .subscriptionName(subscriptionName)
                 .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
@@ -1502,7 +1530,8 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
                     });
                 })
                 .subscribe();
-        pulsarClient.newConsumer(Schema.STRING)
+        @Cleanup
+        Consumer consumer4 = pulsarClient.newConsumer(Schema.STRING)
                 .topic(topic)
                 .subscriptionName(subscriptionName)
                 .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
@@ -1522,5 +1551,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         // wait for all the messages to be delivered
         count3.await();
         assertTrue(sentMessages.isEmpty(), "didn't receive " + sentMessages);
+
+        producerFuture.get();
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
@@ -27,7 +27,6 @@ import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import com.google.common.collect.Sets;
-import java.lang.reflect.Field;
 import java.net.URL;
 import java.util.HashSet;
 import java.util.Optional;
@@ -39,7 +38,6 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 import lombok.Cleanup;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
@@ -700,15 +698,6 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             conf.setLoadManagerClassName(loadManagerName);
             startBroker();
 
-            Field field = PulsarService.class.getDeclaredField("loadManager");
-            field.setAccessible(true);
-            @SuppressWarnings("unchecked")
-            AtomicReference<LoadManager> loadManagerRef = (AtomicReference<LoadManager>) field.get(pulsar);
-            LoadManager manager = LoadManager.create(pulsar);
-            manager.start();
-            LoadManager oldLoadManager = loadManagerRef.getAndSet(manager);
-            oldLoadManager.stop();
-
             NamespaceBundle fdqn = pulsar.getNamespaceService().getBundle(TopicName.get(topicName));
             LoadManager loadManager = pulsar.getLoadManager().get();
             ResourceUnit broker = null;
@@ -788,15 +777,6 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             conf.setEnablePersistentTopics(false);
             conf.setLoadManagerClassName(loadManagerName);
             startBroker();
-
-            Field field = PulsarService.class.getDeclaredField("loadManager");
-            field.setAccessible(true);
-            @SuppressWarnings("unchecked")
-            AtomicReference<LoadManager> loadManagerRef = (AtomicReference<LoadManager>) field.get(pulsar);
-            LoadManager manager = LoadManager.create(pulsar);
-            manager.start();
-            LoadManager oldLoadManager = loadManagerRef.getAndSet(manager);
-            oldLoadManager.stop();
 
             NamespaceBundle fdqn = pulsar.getNamespaceService().getBundle(TopicName.get(topicName));
             LoadManager loadManager = pulsar.getLoadManager().get();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleSchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleSchemaTest.java
@@ -61,8 +61,9 @@ import org.apache.pulsar.common.schema.LongSchemaVersion;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
@@ -70,6 +71,8 @@ import org.testng.annotations.Test;
 @Test(groups = "broker-api")
 @Slf4j
 public class SimpleSchemaTest extends ProducerConsumerBase {
+
+    private static final String NAMESPACE = "my-property/my-ns";
 
     @DataProvider(name = "batchingModes")
     public static Object[][] batchingModes() {
@@ -111,7 +114,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
     }
 
 
-    @BeforeMethod
+    @BeforeClass
     @Override
     protected void setup() throws Exception {
         conf.setSchemaValidationEnforced(schemaValidationEnforced);
@@ -120,19 +123,32 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
         super.producerBaseSetup();
     }
 
-    @AfterMethod(alwaysRun = true)
+    @AfterClass(alwaysRun = true)
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();
     }
 
+    @AfterMethod(alwaysRun = true)
+    public void resetNamespace() throws Exception {
+        List<String> list = admin.namespaces().getTopics(NAMESPACE);
+        for (String topicName : list){
+            if (!pulsar.getBrokerService().isSystemTopic(topicName)) {
+                admin.topics().delete(topicName, false);
+            }
+        }
+        PulsarClientImpl pulsarClientImpl = (PulsarClientImpl) pulsarClient;
+        pulsarClientImpl.getSchemaProviderLoadingCache().invalidateAll();
+    }
+
     @Test
     public void testString() throws Exception {
+        final String topicName = String.format("persistent://%s/my-topic1", NAMESPACE);
         try (Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
-                .topic("persistent://my-property/my-ns/my-topic1")
+                .topic(topicName)
                 .subscriptionName("my-subscriber-name").subscribe();
              Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
-                     .topic("persistent://my-property/my-ns/my-topic1").create()) {
+                     .topic(topicName).create()) {
             int N = 10;
 
             for (int i = 0; i < N; i++) {
@@ -176,7 +192,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void newProducerNewTopicNewSchema() throws Exception {
-        String topic = "my-property/my-ns/schema-test";
+        String topic = NAMESPACE + "/schema-test";
         try (Producer<V1Data> p = pulsarClient.newProducer(Schema.AVRO(V1Data.class))
                 .topic(topic).create()) {
             p.send(new V1Data(0));
@@ -185,7 +201,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void newProducerTopicExistsWithoutSchema() throws Exception {
-        String topic = "my-property/my-ns/schema-test";
+        String topic = NAMESPACE + "/schema-test";
         try (Producer<byte[]> p = pulsarClient.newProducer().topic(topic).create()) {
             p.send(topic.getBytes(UTF_8));
         }
@@ -198,7 +214,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void newProducerTopicExistsWithSchema() throws Exception {
-        String topic = "my-property/my-ns/schema-test";
+        String topic = NAMESPACE + "/schema-test";
         try (Producer<V1Data> p = pulsarClient.newProducer(Schema.AVRO(V1Data.class))
                 .topic(topic).create()) {
             p.send(new V1Data(1));
@@ -212,7 +228,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void newProducerWithoutSchemaOnTopicWithSchema() throws Exception {
-        String topic = "my-property/my-ns/schema-test";
+        String topic = NAMESPACE + "/schema-test";
 
         try (Producer<V1Data> p = pulsarClient.newProducer(Schema.AVRO(V1Data.class))
                 .topic(topic).create()) {
@@ -256,7 +272,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void newProducerForMessageSchemaOnTopicWithMultiVersionSchema() throws Exception {
-        String topic = "my-property/my-ns/schema-test";
+        String topic = NAMESPACE + "/schema-test";
         Schema<V1Data> v1Schema = Schema.AVRO(V1Data.class);
         byte[] v1SchemaBytes = v1Schema.getSchemaInfo().getSchema();
         AvroWriter<V1Data> v1Writer = new AvroWriter<>(
@@ -323,7 +339,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void newNativeAvroProducerForMessageSchemaOnTopicWithMultiVersionSchema() throws Exception {
-        String topic = "my-property/my-ns/schema-test";
+        String topic = NAMESPACE + "/schema-test";
         Schema<V1Data> v1Schema = Schema.AVRO(V1Data.class);
         byte[] v1SchemaBytes = v1Schema.getSchemaInfo().getSchema();
         org.apache.avro.Schema v1SchemaAvroNative = new Parser().parse(new ByteArrayInputStream(v1SchemaBytes));
@@ -390,7 +406,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void newProducerForMessageOnTopicWithDifferentSchemaType() throws Exception {
-        String topic = "my-property/my-ns/schema-test";
+        String topic = NAMESPACE + "/schema-test";
         V1Data data1 = new V1Data(2);
         V2Data data2 = new V2Data(3, 5);
         V1Data data3 = new V1Data(8);
@@ -422,7 +438,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void newProducerForMessageSchemaOnTopicInitialWithNoSchema() throws Exception {
-        String topic = "my-property/my-ns/schema-test";
+        String topic = NAMESPACE + "/schema-test";
         Schema<V1Data> v1Schema = Schema.AVRO(V1Data.class);
         byte[] v1SchemaBytes = v1Schema.getSchemaInfo().getSchema();
         AvroWriter<V1Data> v1Writer = new AvroWriter<>(
@@ -462,7 +478,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void newNativeAvroProducerForMessageSchemaOnTopicInitialWithNoSchema() throws Exception {
-        String topic = "my-property/my-ns/schema-test";
+        String topic = NAMESPACE + "/schema-test";
         Schema<V1Data> v1Schema = Schema.AVRO(V1Data.class);
         byte[] v1SchemaBytes = v1Schema.getSchemaInfo().getSchema();
         org.apache.avro.Schema v1SchemaAvroNative = new Parser().parse(new ByteArrayInputStream(v1SchemaBytes));
@@ -503,10 +519,12 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void newProducerForMessageSchemaWithBatch() throws Exception {
-        String topic = "my-property/my-ns/schema-test";
+        String topic = NAMESPACE + "/schema-test";
+        @Cleanup
         Consumer<V2Data> c = pulsarClient.newConsumer(Schema.AVRO(V2Data.class))
                 .topic(topic)
                 .subscriptionName("sub1").subscribe();
+        @Cleanup
         Producer<byte[]> p = pulsarClient.newProducer(Schema.AUTO_PRODUCE_BYTES())
                 .topic(topic)
                 .enableBatching(true)
@@ -535,6 +553,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
                 try {
                     p.newMessage(Schema.AUTO_PRODUCE_BYTES(Schema.AVRO(IncompatibleData.class)))
                             .value(content).send();
+                    fail("Expect: incompatible schema exception");
                 } catch (Exception e) {
                     Assert.assertTrue(e instanceof IncompatibleSchemaException, e.getMessage());
                 }
@@ -556,7 +575,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void newNativeAvroProducerForMessageSchemaWithBatch() throws Exception {
-        String topic = "my-property/my-ns/schema-test";
+        String topic = NAMESPACE + "/schema-test";
         Schema<V1Data> v1Schema = Schema.AVRO(V1Data.class);
         byte[] v1SchemaBytes = v1Schema.getSchemaInfo().getSchema();
         org.apache.avro.Schema v1SchemaAvroNative = new Parser().parse(new ByteArrayInputStream(v1SchemaBytes));
@@ -566,9 +585,11 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
         org.apache.avro.Schema v2SchemaAvroNative = new Parser().parse(new ByteArrayInputStream(v2SchemaBytes));
         AvroWriter<V2Data> v2Writer = new AvroWriter<>(v2SchemaAvroNative);
 
+        @Cleanup
         Consumer<byte[]> c = pulsarClient.newConsumer(Schema.BYTES)
                 .topic(topic)
                 .subscriptionName("sub1").subscribe();
+        @Cleanup
         Producer<byte[]> p = pulsarClient.newProducer(Schema.NATIVE_AVRO(v1SchemaAvroNative))
                 .topic(topic)
                 .enableBatching(true)
@@ -624,7 +645,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void newProducerWithMultipleSchemaDisabled() throws Exception {
-        String topic = "my-property/my-ns/schema-test";
+        String topic = NAMESPACE + "/schema-test";
         AvroWriter<V1Data> v1DataAvroWriter = new AvroWriter<>(
                 ReflectData.AllowNull.get().getSchema(V1Data.class));
         try (Producer<byte[]> p = pulsarClient.newProducer()
@@ -638,7 +659,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void newConsumerWithSchemaOnNewTopic() throws Exception {
-        String topic = "my-property/my-ns/schema-test";
+        String topic = NAMESPACE + "/schema-test";
 
         try (Consumer<V1Data> c = pulsarClient.newConsumer(Schema.AVRO(V1Data.class))
                 .topic(topic).subscriptionName("sub1").subscribe();
@@ -651,7 +672,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void newConsumerWithSchemaOnExistingTopicWithoutSchema() {
-        String topic = "my-property/my-ns/schema-test";
+        String topic = NAMESPACE + "/schema-test";
 
         try (Producer<byte[]> p = pulsarClient.newProducer().topic(topic).create();
              Consumer<V1Data> c = pulsarClient.newConsumer(Schema.AVRO(V1Data.class))
@@ -664,7 +685,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void newConsumerWithSchemaTopicHasSchema() throws Exception {
-        String topic = "my-property/my-ns/schema-test";
+        String topic = NAMESPACE + "/schema-test";
 
         try (Producer<V1Data> p = pulsarClient.newProducer(Schema.AVRO(V1Data.class)).topic(topic).create();
              Consumer<V1Data> c = pulsarClient.newConsumer(Schema.AVRO(V1Data.class))
@@ -677,7 +698,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void newBytesConsumerWithTopicWithSchema() throws Exception {
-        String topic = "my-property/my-ns/schema-test";
+        String topic = NAMESPACE + "/schema-test";
 
         try (Producer<V1Data> p = pulsarClient.newProducer(Schema.AVRO(V1Data.class)).topic(topic).create();
              Consumer<byte[]> c = pulsarClient.newConsumer().topic(topic).subscriptionName("sub1").subscribe()) {
@@ -697,7 +718,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
     }
 
     private void getSchemaVersionFromMessages(boolean batching) throws Exception {
-        String topic = "my-property/my-ns/schema-test";
+        String topic = NAMESPACE + "/schema-test";
 
         try (Producer<V1Data> p = pulsarClient.newProducer(Schema.AVRO(V1Data.class))
                 .topic(topic)
@@ -718,7 +739,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test(dataProvider = "batchingModes")
     public void testAutoConsume(boolean batching) throws Exception {
-        String topic = "my-property/my-ns/schema-test-auto-consume-" + batching;
+        String topic = NAMESPACE + "/schema-test-auto-consume-" + batching;
 
         try (Producer<V1Data> p = pulsarClient.newProducer(Schema.AVRO(V1Data.class))
                 .topic(topic)
@@ -755,7 +776,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test(dataProvider = "batchingModesAndValueEncodingType")
     public void testAutoKeyValueConsume(boolean batching, KeyValueEncodingType keyValueEncodingType) throws Exception {
-        String topic = "my-property/my-ns/schema-test-auto-keyvalue-consume-" + batching+"-"+keyValueEncodingType;
+        String topic = NAMESPACE + "/schema-test-auto-keyvalue-consume-" + batching+"-"+keyValueEncodingType;
 
         Schema<KeyValue<V1Data, V1Data>> pojoSchema = Schema.KeyValue(
                 Schema.AVRO(V1Data.class),
@@ -1039,7 +1060,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void testAutoKeyValueConsumeGenericObject() throws Exception {
-        String topic = "my-property/my-ns/schema-test-auto-keyvalue-consume-"+ UUID.randomUUID();
+        String topic = NAMESPACE + "/schema-test-auto-keyvalue-consume-"+ UUID.randomUUID();
 
         Schema<KeyValue<V1Data, V1Data>> pojoSchema = Schema.KeyValue(
                 Schema.AVRO(V1Data.class),
@@ -1121,17 +1142,19 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void testGetSchemaByVersion() throws PulsarClientException, PulsarAdminException, ExecutionException, InterruptedException {
-        final String topic = "persistent://my-property/my-ns/testGetSchemaByVersion";
+        final String topic = String.format("persistent://%s/testGetSchemaByVersion", NAMESPACE);
 
         @Cleanup
         PulsarClientImpl httpProtocolClient = (PulsarClientImpl) PulsarClient.builder().serviceUrl(brokerUrl.toString()).build();
         PulsarClientImpl binaryProtocolClient = (PulsarClientImpl) pulsarClient;
 
-        pulsarClient.newProducer(Schema.AVRO(V1Data.class))
+        @Cleanup
+        Producer p1 = pulsarClient.newProducer(Schema.AVRO(V1Data.class))
                 .topic(topic)
                 .create();
 
-        pulsarClient.newProducer(Schema.AVRO(V2Data.class))
+        @Cleanup
+        Producer p2 = pulsarClient.newProducer(Schema.AVRO(V2Data.class))
                 .topic(topic)
                 .create();
 
@@ -1148,7 +1171,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test
     public void testGetNativeSchemaWithAutoConsumeWithMultiVersion() throws Exception {
-        final String topic = "persistent://my-property/my-ns/testGetSchemaWithMultiVersion";
+        final String topic = String.format("persistent://%s/testGetSchemaWithMultiVersion", NAMESPACE);
 
         @Cleanup
         Consumer<?> consumer = pulsarClient.newConsumer(Schema.AUTO_CONSUME())
@@ -1188,8 +1211,8 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test(dataProvider = "topicDomain")
     public void testAutoCreatedSchema(String domain) throws Exception {
-        final String topic1 = domain + "my-property/my-ns/testAutoCreatedSchema-1";
-        final String topic2 = domain + "my-property/my-ns/testAutoCreatedSchema-2";
+        final String topic1 = domain + NAMESPACE + "/testAutoCreatedSchema-1";
+        final String topic2 = domain + NAMESPACE + "/testAutoCreatedSchema-2";
 
         pulsarClient.newProducer(Schema.BYTES).topic(topic1).create().close();
         try {
@@ -1223,7 +1246,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
 
     @Test(dataProvider = "keyEncodingType")
     public void testAutoKeyValueConsumeGenericObjectNullValues(KeyValueEncodingType encodingType) throws Exception {
-        String topic = "my-property/my-ns/schema-test-auto-keyvalue-" + encodingType + "-null-value-consume-" + UUID.randomUUID();
+        String topic = NAMESPACE + "/schema-test-auto-keyvalue-" + encodingType + "-null-value-consume-" + UUID.randomUUID();
 
         Schema<KeyValue<V1Data, V1Data>> pojoSchema = Schema.KeyValue(
                 Schema.AVRO(V1Data.class),
@@ -1275,7 +1298,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
         if (schemaValidationEnforced) {
             return;
         }
-        final String topic = "test-consume-avro-messages-without-schema-" + UUID.randomUUID();
+        final String topic = NAMESPACE + "/test-consume-avro-messages-without-schema-" + UUID.randomUUID();
         final Schema<V1Data> schema = Schema.AVRO(V1Data.class);
         final Consumer<V1Data> consumer = pulsarClient.newConsumer(schema)
                 .topic(topic)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactedTopicImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactedTopicImplTest.java
@@ -1,0 +1,147 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.compaction;
+
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.TreeMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.apache.bookkeeper.mledger.impl.PositionImpl;
+import org.apache.pulsar.common.api.proto.MessageIdData;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+@Test(groups = "broker-compaction")
+public class CompactedTopicImplTest {
+
+    private static final long DEFAULT_LEDGER_ID = 1;
+
+    // Sparse ledger makes multi entry has same data, this is used to construct complex environments to verify that the
+    // smallest position with the correct data is found.
+    private static final TreeMap<Long, Long> ORIGIN_SPARSE_LEDGER = new TreeMap<>();
+
+    static {
+        ORIGIN_SPARSE_LEDGER.put(0L, 0L);
+        ORIGIN_SPARSE_LEDGER.put(1L, 1L);
+        ORIGIN_SPARSE_LEDGER.put(2L, 1001L);
+        ORIGIN_SPARSE_LEDGER.put(3L, 1002L);
+        ORIGIN_SPARSE_LEDGER.put(4L, 1003L);
+        ORIGIN_SPARSE_LEDGER.put(10L, 1010L);
+        ORIGIN_SPARSE_LEDGER.put(20L, 1020L);
+        ORIGIN_SPARSE_LEDGER.put(50L, 1050L);
+        ORIGIN_SPARSE_LEDGER.put(Long.MAX_VALUE, Long.MAX_VALUE);
+    }
+
+    @DataProvider(name = "argsForFindStartPointLoop")
+    public Object[][] argsForFindStartPointLoop() {
+        return new Object[][]{
+                {0, 100, 0},// first value.
+                {0, 100, 1},// second value.
+                {0, 100, 1003},// not first value.
+                {0, 100, 1015},// value not exists.
+                {3, 40, 50},// less than first value & find in a range.
+                {3, 40, 1002},// first value & find in a range.
+                {3, 40, 1003},// second value & find in a range.
+                {3, 40, 1010},// not first value & find in a range.
+                {3, 40, 1015}// value not exists & find in a range.
+        };
+    }
+
+    private static CacheLoader<Long, MessageIdData> mockCacheLoader(long start, long end, final long targetMessageId,
+                                                                    AtomicLong bingoMarker) {
+        // Mock ledger.
+        final TreeMap<Long, Long> sparseLedger = new TreeMap<>();
+        sparseLedger.putAll(ORIGIN_SPARSE_LEDGER.subMap(start, end + 1));
+        sparseLedger.put(Long.MAX_VALUE, Long.MAX_VALUE);
+
+        Function<Long, Long> findMessageIdFunc = entryId -> sparseLedger.ceilingEntry(entryId).getValue();
+
+        // Calculate the correct position.
+        for (long i = start; i <= end; i++) {
+            if (findMessageIdFunc.apply(i) >= targetMessageId) {
+                bingoMarker.set(i);
+                break;
+            }
+        }
+
+        return new CacheLoader<Long, MessageIdData>() {
+            @Override
+            public @Nullable MessageIdData load(@NonNull Long entryId) throws Exception {
+                MessageIdData messageIdData = new MessageIdData();
+                messageIdData.setLedgerId(DEFAULT_LEDGER_ID);
+                messageIdData.setEntryId(findMessageIdFunc.apply(entryId));
+                return messageIdData;
+            }
+        };
+    }
+
+    @Test(dataProvider = "argsForFindStartPointLoop")
+    public void testFindStartPointLoop(long start, long end, long targetMessageId) {
+        AtomicLong bingoMarker = new AtomicLong();
+        // Mock cache.
+        AsyncLoadingCache<Long, MessageIdData> cache = Caffeine.newBuilder()
+                .buildAsync(mockCacheLoader(start, end, targetMessageId, bingoMarker));
+        // Do test.
+        PositionImpl targetPosition = PositionImpl.get(DEFAULT_LEDGER_ID, targetMessageId);
+        CompletableFuture<Long> promise = new CompletableFuture<>();
+        CompactedTopicImpl.findStartPointLoop(targetPosition, start, end, promise, cache);
+        long result = promise.join();
+        assertEquals(result, bingoMarker.get());
+    }
+
+    /**
+     * Why should we check the recursion number of "findStartPointLoop", see: #17976
+     */
+    @Test
+    public void testRecursionNumberOfFindStartPointLoop() {
+        AtomicLong bingoMarker = new AtomicLong();
+        long start = 0;
+        long end = 100;
+        long targetMessageId = 1;
+        // Mock cache.
+        AsyncLoadingCache<Long, MessageIdData> cache = Caffeine.newBuilder()
+                .buildAsync(mockCacheLoader(start, end, targetMessageId, bingoMarker));
+        AtomicInteger invokeCounterOfCacheGet = new AtomicInteger();
+        AsyncLoadingCache<Long, MessageIdData> cacheWithCounter = spy(cache);
+        doAnswer(invocation -> {
+            invokeCounterOfCacheGet.incrementAndGet();
+            return cache.get((Long) invocation.getArguments()[0]);
+        }).when(cacheWithCounter).get(anyLong());
+        // Because when "findStartPointLoop(...)" is executed, will trigger "cache.get()" three times, including
+        // "cache.get(start)", "cache.get(mid)" and "cache.get(end)". Therefore, we can calculate the count of
+        // executed "findStartPointLoop".
+        Supplier<Integer> loopCounter = () -> invokeCounterOfCacheGet.get() / 3;
+        // Do test.
+        PositionImpl targetPosition = PositionImpl.get(DEFAULT_LEDGER_ID, targetMessageId);
+        CompletableFuture<Long> promise = new CompletableFuture<>();
+        CompactedTopicImpl.findStartPointLoop(targetPosition, start, end, promise, cacheWithCounter);
+        // Do verify.
+        promise.join();
+        assertEquals(loopCounter.get().intValue(), 2);
+    }
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
@@ -141,6 +141,9 @@ public class ClientCnx extends PulsarHandler {
 
     private final CompletableFuture<Void> connectionFuture = new CompletableFuture<Void>();
     private final ConcurrentLinkedQueue<RequestTime> requestTimeoutQueue = new ConcurrentLinkedQueue<>();
+
+    @VisibleForTesting
+    @Getter(AccessLevel.PACKAGE)
     private final Semaphore pendingLookupRequestSemaphore;
     private final Semaphore maxLookupRequestSemaphore;
     private final EventLoopGroup eventLoopGroup;
@@ -780,6 +783,11 @@ public class ClientCnx extends PulsarHandler {
         TimedCompletableFuture<LookupDataResult> future = new TimedCompletableFuture<>();
 
         if (pendingLookupRequestSemaphore.tryAcquire()) {
+            future.whenComplete((lookupDataResult, throwable) -> {
+                if (throwable instanceof ConnectException) {
+                    pendingLookupRequestSemaphore.release();
+                }
+            });
             addPendingLookupRequests(requestId, future);
             ctx.writeAndFlush(request).addListener(writeFuture -> {
                 if (!writeFuture.isSuccess()) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -38,8 +38,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.pulsar.client.api.BatchReceivePolicy;
@@ -95,7 +93,6 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
             .newUpdater(ConsumerBase.class, "incomingMessagesSize");
     protected volatile long incomingMessagesSize = 0;
     protected volatile Timeout batchReceiveTimeout = null;
-    protected final Lock reentrantLock = new ReentrantLock();
 
     protected static final AtomicLongFieldUpdater<ConsumerBase> CONSUMER_EPOCH =
             AtomicLongFieldUpdater.newUpdater(ConsumerBase.class, "consumerEpoch");
@@ -910,13 +907,7 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
         if (opBatchReceive == null) {
             return;
         }
-
-        reentrantLock.lock();
-        try {
-            notifyPendingBatchReceivedCallBack(opBatchReceive.future);
-        } finally {
-            reentrantLock.unlock();
-        }
+        notifyPendingBatchReceivedCallBack(opBatchReceive.future);
     }
 
     private boolean hasNextBatchReceive() {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/PortManager.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/PortManager.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.util;
+
+import java.net.ServerSocket;
+import java.util.HashSet;
+import java.util.Set;
+
+public class PortManager {
+
+    private static final Set<Integer> PORTS = new HashSet<>();
+
+    /**
+     * Return a locked available port.
+     *
+     * @return locked available port.
+     */
+    public static synchronized int nextLockedFreePort() {
+        int exceptionCount = 0;
+        while (true) {
+            try (ServerSocket ss = new ServerSocket(0)) {
+                int port = ss.getLocalPort();
+                if (!checkPortIfLocked(port)) {
+                    PORTS.add(port);
+                    return port;
+                }
+            } catch (Exception e) {
+                exceptionCount++;
+                if (exceptionCount > 100) {
+                    throw new RuntimeException("Unable to allocate socket port", e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns whether the port was released successfully.
+     *
+     * @return whether the release is successful.
+     */
+    public static synchronized boolean releaseLockedPort(int lockedPort) {
+        return PORTS.remove(lockedPort);
+    }
+
+    /**
+     * Check port if locked.
+     *
+     * @return whether the port is locked.
+     */
+    public static synchronized boolean checkPortIfLocked(int lockedPort) {
+        return PORTS.contains(lockedPort);
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/RateLimiter.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/RateLimiter.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.common.util;
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.pulsar.common.util.Runnables.catchingAndLoggingThrowables;
 import com.google.common.base.MoreObjects;
+import io.netty.util.concurrent.DefaultThreadFactory;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -80,7 +81,8 @@ public class RateLimiter implements AutoCloseable{
             this.executorService = scheduledExecutorService;
             this.externalExecutor = true;
         } else {
-            final ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1);
+            final ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1,
+                    new DefaultThreadFactory("pulsar-rate-limiter"));
             executor.setContinueExistingPeriodicTasksAfterShutdownPolicy(false);
             executor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
             this.executorService = executor;

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/PortManagerTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/PortManagerTest.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.util;
+
+import org.testng.annotations.Test;
+
+import static org.apache.pulsar.common.util.PortManager.checkPortIfLocked;
+import static org.apache.pulsar.common.util.PortManager.nextLockedFreePort;
+import static org.apache.pulsar.common.util.PortManager.releaseLockedPort;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class PortManagerTest {
+    @Test
+    public void testCheckPortIfLockedAndRemove() {
+        int port = nextLockedFreePort();
+        assertTrue(checkPortIfLocked(port));
+        assertTrue(releaseLockedPort(port));
+        assertFalse(checkPortIfLocked(port));
+    }
+}

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/io/ConnectorUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/io/ConnectorUtils.java
@@ -160,15 +160,13 @@ public class ConnectorUtils {
                 archives.add(archive);
             }
         }
-
         if (archives.isEmpty()) {
-            log.warn("Connectors archive directory is empty");
             return new TreeMap<>();
         }
 
         ExecutorService oneTimeExecutor = null;
         try {
-            int nThreads = Math.min(4, archives.size());
+            int nThreads = Math.min(Runtime.getRuntime().availableProcessors(), archives.size());
             log.info("Loading {} connector definitions with a thread pool of size {}", archives.size(), nThreads);
             oneTimeExecutor = Executors.newFixedThreadPool(nThreads,
                     new ThreadFactoryBuilder().setNameFormat("search-connectors-executor-%d").build());

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/io/ConnectorUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/io/ConnectorUtils.java
@@ -169,7 +169,7 @@ public class ConnectorUtils {
             int nThreads = Math.min(Runtime.getRuntime().availableProcessors(), archives.size());
             log.info("Loading {} connector definitions with a thread pool of size {}", archives.size(), nThreads);
             oneTimeExecutor = Executors.newFixedThreadPool(nThreads,
-                    new ThreadFactoryBuilder().setNameFormat("search-connectors-executor-%d").build());
+                    new ThreadFactoryBuilder().setNameFormat("connector-extraction-executor-%d").build());
             List<CompletableFuture<Map.Entry<String, Connector>>> futures = new ArrayList<>();
             for (Path archive : archives) {
                 CompletableFuture future = CompletableFuture.supplyAsync(() ->

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
@@ -324,26 +324,22 @@ public abstract class ComponentImpl implements Component<PulsarWorkerService> {
             // For externally managed schedulers, the pkgUrl/builtin stuff can be copied to bk
             // if the function worker image does not include connectors
             if (!isEmpty(builtin)) {
+                File component;
+                switch (componentType) {
+                    case SOURCE:
+                        component = worker().getConnectorsManager().getSourceArchive(builtin).toFile();
+                        break;
+                    case SINK:
+                        component = worker().getConnectorsManager().getSinkArchive(builtin).toFile();
+                        break;
+                    default:
+                        component = worker().getFunctionsManager().getFunctionArchive(builtin).toFile();
+                        break;
+                }
+                packageLocationMetaDataBuilder.setOriginalFileName(component.getName());
                 if (worker().getWorkerConfig().getUploadBuiltinSinksSources()) {
-                    File component;
-                    String archiveName;
-                    switch (componentType) {
-                        case SOURCE:
-                            archiveName = functionDetails.getSource().getBuiltin();
-                            component = worker().getConnectorsManager().getSourceArchive(archiveName).toFile();
-                            break;
-                        case SINK:
-                            archiveName = functionDetails.getSink().getBuiltin();
-                            component = worker().getConnectorsManager().getSinkArchive(archiveName).toFile();
-                            break;
-                        default:
-                            archiveName = functionDetails.getBuiltin();
-                            component = worker().getFunctionsManager().getFunctionArchive(archiveName).toFile();
-                            break;
-                    }
                     packageLocationMetaDataBuilder.setPackagePath(createPackagePath(tenant, namespace, componentName,
                             component.getName()));
-                    packageLocationMetaDataBuilder.setOriginalFileName(component.getName());
                     if (isPackageManagementEnabled) {
                         packageLocationMetaDataBuilder.setPackagePath(packageName.toString());
                         worker().getBrokerAdmin().packages().upload(metadata,

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/SinksImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/SinksImpl.java
@@ -433,8 +433,8 @@ public class SinksImpl extends ComponentImpl implements Sinks<PulsarWorkerServic
                                                  Function.FunctionDetails functionDetails, String transformFunction) {
         File functionPackageFile = null;
         try {
-            String builtin = null;
-            if (!transformFunction.startsWith(Utils.BUILTIN)) {
+            String builtin = functionDetails.getBuiltin();
+            if (isBlank(builtin)) {
                 functionPackageFile = getPackageFile(transformFunction);
             }
             Function.PackageLocationMetaData.Builder functionPackageLocation =

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/FunctionApiV3ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/FunctionApiV3ResourceTest.java
@@ -776,6 +776,7 @@ public class FunctionApiV3ResourceTest {
                 .classLoader(mockedClassLoader)
                 .build();
         when(mockedFunctionsManager.getFunction("exclamation")).thenReturn(functionArchive);
+        when(mockedFunctionsManager.getFunctionArchive(any())).thenReturn(getPulsarApiExamplesNar().toPath());
 
         when(mockedWorkerService.getFunctionsManager()).thenReturn(mockedFunctionsManager);
 

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SinkApiV3ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SinkApiV3ResourceTest.java
@@ -1754,14 +1754,14 @@ public class SinkApiV3ResourceTest {
             ctx.when(() -> FunctionCommon.getClassLoaderFromPackage(any(), any(), any(), any())).thenCallRealMethod();
             ctx.when(() -> FunctionCommon.isFunctionCodeBuiltin(any())).thenReturn(true);
             ctx.when(() -> FunctionCommon.extractNarClassLoader(any(), any())).thenReturn(mockedClassLoader);
-
         });
 
         ConnectorsManager mockedConnManager = mock(ConnectorsManager.class);
         Connector connector = Connector.builder()
-                .classLoader(mockedClassLoader)
-                .build();
+            .classLoader(mockedClassLoader)
+            .build();
         when(mockedConnManager.getConnector("cassandra")).thenReturn(connector);
+        when(mockedConnManager.getSinkArchive(any())).thenReturn(getPulsarIOCassandraNar().toPath());
         when(mockedWorkerService.getConnectorsManager()).thenReturn(mockedConnManager);
 
         when(mockedRuntimeFactory.externallyManaged()).thenReturn(true);

--- a/pulsar-io/jdbc/mariadb/src/main/java/org/apache/pulsar/io/jdbc/MariadbJdbcAutoSchemaSink.java
+++ b/pulsar-io/jdbc/mariadb/src/main/java/org/apache/pulsar/io/jdbc/MariadbJdbcAutoSchemaSink.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.io.jdbc;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.apache.pulsar.io.core.annotations.Connector;
 import org.apache.pulsar.io.core.annotations.IOType;
 

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/BookieServiceInfoSerde.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/BookieServiceInfoSerde.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.discover.BookieServiceInfo;
+import org.apache.bookkeeper.discover.BookieServiceInfoUtils;
 import org.apache.bookkeeper.proto.DataFormats.BookieServiceInfoFormat;
 import org.apache.pulsar.metadata.api.MetadataSerde;
 import org.apache.pulsar.metadata.api.Stat;
@@ -63,7 +64,57 @@ public class BookieServiceInfoSerde implements MetadataSerde<BookieServiceInfo> 
     }
 
     @Override
-    public BookieServiceInfo deserialize(String path, byte[] content, Stat stat) throws IOException {
-        return null;
+    public BookieServiceInfo deserialize(String path, byte[] bookieServiceInfo, Stat stat) throws IOException {
+        // see https://github.com/apache/bookkeeper/blob/
+        // 034ef8566ad037937a4d58a28f70631175744f53/bookkeeper-server/
+        // src/main/java/org/apache/bookkeeper/discover/ZKRegistrationClient.java#L311
+        String bookieId = extractBookiedIdFromPath(path);
+        if (bookieServiceInfo == null || bookieServiceInfo.length == 0) {
+            return BookieServiceInfoUtils.buildLegacyBookieServiceInfo(bookieId);
+        }
+
+        BookieServiceInfoFormat builder = BookieServiceInfoFormat.parseFrom(bookieServiceInfo);
+        BookieServiceInfo bsi = new BookieServiceInfo();
+        List<BookieServiceInfo.Endpoint> endpoints = builder.getEndpointsList().stream()
+                .map(e -> {
+                    BookieServiceInfo.Endpoint endpoint = new BookieServiceInfo.Endpoint();
+                    endpoint.setId(e.getId());
+                    endpoint.setPort(e.getPort());
+                    endpoint.setHost(e.getHost());
+                    endpoint.setProtocol(e.getProtocol());
+                    endpoint.setAuth(e.getAuthList());
+                    endpoint.setExtensions(e.getExtensionsList());
+                    return endpoint;
+                })
+                .collect(Collectors.toList());
+
+        bsi.setEndpoints(endpoints);
+        bsi.setProperties(builder.getPropertiesMap());
+
+        return bsi;
+
+    }
+
+    /**
+     * Extract the BookieId
+     * The path should look like /ledgers/available/bookieId
+     * or /ledgers/available/readonly/bookieId.
+     * But the prefix depends on the configuration.
+     * @param path
+     * @return the bookieId
+     */
+    private static String extractBookiedIdFromPath(String path) throws IOException {
+        // https://github.com/apache/bookkeeper/blob/
+        // 034ef8566ad037937a4d58a28f70631175744f53/bookkeeper-server/
+        // src/main/java/org/apache/bookkeeper/discover/ZKRegistrationClient.java#L258
+        if (path == null) {
+            path = "";
+        }
+        int last = path.lastIndexOf("/");
+        if (last >= 0) {
+            return path.substring(last + 1);
+        } else {
+            throw new IOException("The path " + path + " doesn't look like a valid path for a BookieServiceInfo node");
+        }
     }
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarRegistrationClient.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarRegistrationClient.java
@@ -22,22 +22,33 @@ import static org.apache.bookkeeper.util.BookKeeperConstants.AVAILABLE_NODE;
 import static org.apache.bookkeeper.util.BookKeeperConstants.COOKIE_NODE;
 import static org.apache.bookkeeper.util.BookKeeperConstants.READONLY;
 import io.netty.util.concurrent.DefaultThreadFactory;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.client.BKException;
+import org.apache.bookkeeper.common.concurrent.FutureUtils;
+import org.apache.bookkeeper.discover.BookieServiceInfo;
 import org.apache.bookkeeper.discover.RegistrationClient;
 import org.apache.bookkeeper.net.BookieId;
+import org.apache.bookkeeper.versioning.LongVersion;
 import org.apache.bookkeeper.versioning.Version;
 import org.apache.bookkeeper.versioning.Versioned;
+import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.metadata.api.MetadataCache;
 import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.Notification;
 import org.apache.pulsar.metadata.api.NotificationType;
 
+@Slf4j
 public class PulsarRegistrationClient implements RegistrationClient {
 
     private final MetadataStore store;
@@ -47,14 +58,18 @@ public class PulsarRegistrationClient implements RegistrationClient {
     private final String bookieAllRegistrationPath;
     private final String bookieReadonlyRegistrationPath;
 
+    private final ConcurrentHashMap<BookieId, Versioned<BookieServiceInfo>> bookieServiceInfoCache =
+                                                                                    new ConcurrentHashMap();
     private final Map<RegistrationListener, Boolean> writableBookiesWatchers = new ConcurrentHashMap<>();
     private final Map<RegistrationListener, Boolean> readOnlyBookiesWatchers = new ConcurrentHashMap<>();
+    private final MetadataCache<BookieServiceInfo> bookieServiceInfoMetadataCache;
     private final ScheduledExecutorService executor;
 
     public PulsarRegistrationClient(MetadataStore store,
                                     String ledgersRootPath) {
         this.store = store;
         this.ledgersRootPath = ledgersRootPath;
+        this.bookieServiceInfoMetadataCache = store.getMetadataCache(BookieServiceInfoSerde.INSTANCE);
 
         // Following Bookie Network Address Changes is an expensive operation
         // as it requires additional ZooKeeper watches
@@ -99,7 +114,25 @@ public class PulsarRegistrationClient implements RegistrationClient {
 
     private CompletableFuture<Versioned<Set<BookieId>>> getChildren(String path) {
         return store.getChildren(path)
-                .thenApply(PulsarRegistrationClient::convertToBookieAddresses)
+                .thenComposeAsync(children -> {
+                    Set<BookieId> bookieIds = PulsarRegistrationClient.convertToBookieAddresses(children);
+                    Set<BookieId> bookies = convertToBookieAddresses(children);
+                    List<CompletableFuture<Versioned<BookieServiceInfo>>> bookieInfoUpdated =
+                            new ArrayList<>(bookies.size());
+                    for (BookieId id : bookies) {
+                        // update the cache for new bookies
+                        if (!bookieServiceInfoCache.containsKey(id)) {
+                            bookieInfoUpdated.add(readBookieServiceInfoAsync(id));
+                        }
+                    }
+                    if (bookieInfoUpdated.isEmpty()) {
+                        return CompletableFuture.completedFuture(bookieIds);
+                    } else {
+                        return FutureUtil
+                                .waitForAll(bookieInfoUpdated)
+                                .thenApply(___ -> bookieIds);
+                    }
+                })
                 .thenApply(s -> new Versioned<>(s, Version.NEW));
     }
 
@@ -129,10 +162,20 @@ public class PulsarRegistrationClient implements RegistrationClient {
 
     private void updatedBookies(Notification n) {
         if (n.getType() == NotificationType.Created || n.getType() == NotificationType.Deleted) {
+
+            if (n.getType() == NotificationType.Deleted) {
+                BookieId bookieId = stripBookieIdFromPath(n.getPath());
+                log.info("Bookie {} disappeared", bookieId);
+                if (bookieId != null) {
+                    bookieServiceInfoCache.remove(bookieId);
+                }
+            }
+
             if (n.getPath().startsWith(bookieReadonlyRegistrationPath)) {
-                getReadOnlyBookies().thenAccept(bookies ->
-                        readOnlyBookiesWatchers.keySet()
-                                .forEach(w -> executor.execute(() -> w.onBookiesChanged(bookies))));
+                getReadOnlyBookies().thenAccept(bookies -> {
+                    readOnlyBookiesWatchers.keySet()
+                            .forEach(w -> executor.execute(() -> w.onBookiesChanged(bookies)));
+                });
             } else if (n.getPath().startsWith(bookieRegistrationPath)) {
                 getWritableBookies().thenAccept(bookies ->
                         writableBookiesWatchers.keySet()
@@ -140,6 +183,22 @@ public class PulsarRegistrationClient implements RegistrationClient {
             }
         }
     }
+
+    private static BookieId stripBookieIdFromPath(String path) {
+        if (path == null) {
+            return null;
+        }
+        final int slash = path.lastIndexOf('/');
+        if (slash >= 0) {
+            try {
+                return BookieId.parse(path.substring(slash + 1));
+            } catch (IllegalArgumentException e) {
+                log.warn("Cannot decode bookieId from {}", path, e);
+            }
+        }
+        return null;
+    }
+
 
     private static Set<BookieId> convertToBookieAddresses(List<String> children) {
         // Read the bookie addresses into a set for efficient lookup
@@ -152,5 +211,57 @@ public class PulsarRegistrationClient implements RegistrationClient {
             newBookieAddrs.add(bookieAddr);
         }
         return newBookieAddrs;
+    }
+
+    @Override
+    public CompletableFuture<Versioned<BookieServiceInfo>> getBookieServiceInfo(BookieId bookieId) {
+        // this method cannot perform blocking calls to the MetadataStore
+        // or return a CompletableFuture that is completed on the MetadataStore main thread
+        // this is because there are a few cases in which some operations on the main thread
+        // wait for the result. This is due to the fact that resolving the address of a bookie
+        // is needed in many code paths.
+        Versioned<BookieServiceInfo> resultFromCache = bookieServiceInfoCache.get(bookieId);
+        if (log.isDebugEnabled()) {
+            log.debug("getBookieServiceInfo {} -> {}", bookieId, resultFromCache);
+        }
+        if (resultFromCache != null) {
+            return CompletableFuture.completedFuture(resultFromCache);
+        } else {
+            return FutureUtils.exception(new BKException.BKBookieHandleNotAvailableException());
+        }
+    }
+
+    public CompletableFuture<Versioned<BookieServiceInfo>> readBookieServiceInfoAsync(BookieId bookieId) {
+        String asWritable = bookieRegistrationPath + "/" + bookieId;
+        return bookieServiceInfoMetadataCache.get(asWritable)
+                .thenCompose((Optional<BookieServiceInfo> getResult) -> {
+                    if (getResult.isPresent()) {
+                        Versioned<BookieServiceInfo> res =
+                                new Versioned<>(getResult.get(), new LongVersion(-1));
+                        log.info("Update BookieInfoCache (writable bookie) {} -> {}", bookieId, getResult.get());
+                        bookieServiceInfoCache.put(bookieId, res);
+                        return CompletableFuture.completedFuture(res);
+                    } else {
+                        return readBookieInfoAsReadonlyBookie(bookieId);
+                    }
+                }
+        );
+    }
+
+    final CompletableFuture<Versioned<BookieServiceInfo>> readBookieInfoAsReadonlyBookie(BookieId bookieId) {
+        String asReadonly = bookieReadonlyRegistrationPath + "/" + bookieId;
+        return bookieServiceInfoMetadataCache.get(asReadonly)
+                .thenApply((Optional<BookieServiceInfo> getResultAsReadOnly) -> {
+                    if (getResultAsReadOnly.isPresent()) {
+                        Versioned<BookieServiceInfo> res =
+                                new Versioned<>(getResultAsReadOnly.get(), new LongVersion(-1));
+                        log.info("Update BookieInfoCache (readonly bookie) {} -> {}", bookieId,
+                                getResultAsReadOnly.get());
+                        bookieServiceInfoCache.put(bookieId, res);
+                        return res;
+                    } else {
+                        throw new CompletionException(new BKException.BKBookieHandleNotAvailableException());
+                    }
+                });
     }
 }

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarRegistrationClientTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarRegistrationClientTest.java
@@ -23,6 +23,8 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -112,6 +114,66 @@ public class PulsarRegistrationClientTest extends BaseMetadataStoreTest {
         Versioned<Set<BookieId>> result = result(rc.getReadOnlyBookies());
 
         assertEquals(result.getValue().size(), addresses.size());
+    }
+
+    @Test(dataProvider = "impl")
+    public void testGetBookieServiceInfo(String provider, Supplier<String> urlSupplier) throws Exception {
+        @Cleanup
+        MetadataStoreExtended store =
+                MetadataStoreExtended.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+
+        String ledgersRoot = "/test/ledgers-" + UUID.randomUUID();
+
+        @Cleanup
+        RegistrationManager rm = new PulsarRegistrationManager(store, ledgersRoot, mock(AbstractConfiguration.class));
+
+        @Cleanup
+        RegistrationClient rc = new PulsarRegistrationClient(store, ledgersRoot);
+
+        List<BookieId> addresses = new ArrayList<>(prepareNBookies(10));
+        List<BookieServiceInfo> bookieServiceInfos = new ArrayList<>();
+        int port = 223;
+        for (BookieId address : addresses) {
+            BookieServiceInfo info = new BookieServiceInfo();
+            BookieServiceInfo.Endpoint endpoint = new BookieServiceInfo.Endpoint();
+            endpoint.setAuth(Collections.emptyList());
+            endpoint.setExtensions(Collections.emptyList());
+            endpoint.setId("id");
+            endpoint.setHost("localhost");
+            endpoint.setPort(port++);
+            endpoint.setProtocol("bookie-rpc");
+            info.setEndpoints(Arrays.asList(endpoint));
+            bookieServiceInfos.add(info);
+            // some readonly, some writable
+            boolean readOnly = port % 2 == 0;
+            rm.registerBookie(address, readOnly, info);
+        }
+
+        // trigger loading the BookieServiceInfo in the local cache
+        rc.getAllBookies().join();
+
+        int i = 0;
+        for (BookieId address : addresses) {
+            BookieServiceInfo bookieServiceInfo = rc.getBookieServiceInfo(address).get().getValue();
+            compareBookieServiceInfo(bookieServiceInfo, bookieServiceInfos.get(i++));
+        }
+
+    }
+
+    private void compareBookieServiceInfo(BookieServiceInfo a, BookieServiceInfo b) {
+        assertEquals(a.getProperties(), b.getProperties());
+        assertEquals(a.getEndpoints().size(), b.getEndpoints().size());
+        for (int i = 0; i < a.getEndpoints().size(); i++) {
+            BookieServiceInfo.Endpoint e1 = a.getEndpoints().get(i);
+            BookieServiceInfo.Endpoint e2 = b.getEndpoints().get(i);
+            assertEquals(e1.getHost(), e2.getHost());
+            assertEquals(e1.getPort(), e2.getPort());
+            assertEquals(e1.getId(), e2.getId());
+            assertEquals(e1.getProtocol(), e2.getProtocol());
+            assertEquals(e1.getExtensions(), e2.getExtensions());
+            assertEquals(e1.getAuth(), e2.getAuth());
+        }
+
     }
 
     @Test(dataProvider = "impl")

--- a/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -27,6 +27,7 @@ import static org.apache.bookkeeper.bookie.BookKeeperServerStats.BOOKIE_SCOPE;
 import static org.apache.bookkeeper.bookie.BookKeeperServerStats.LD_INDEX_SCOPE;
 import static org.apache.bookkeeper.bookie.BookKeeperServerStats.LD_LEDGER_SCOPE;
 import static org.apache.bookkeeper.util.BookKeeperConstants.AVAILABLE_NODE;
+import static org.apache.pulsar.common.util.PortManager.nextLockedFreePort;
 import static org.testng.Assert.assertFalse;
 import com.google.common.base.Stopwatch;
 import java.io.File;
@@ -83,7 +84,7 @@ import org.apache.bookkeeper.test.TmpDirs;
 import org.apache.bookkeeper.test.ZooKeeperCluster;
 import org.apache.bookkeeper.test.ZooKeeperClusterUtil;
 import org.apache.bookkeeper.util.DiskChecker;
-import org.apache.bookkeeper.util.PortManager;
+import org.apache.pulsar.common.util.PortManager;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooKeeper;
 import org.slf4j.Logger;
@@ -128,6 +129,8 @@ public abstract class BookKeeperClusterTestCase {
     private final ByteBufAllocatorWithOomHandler allocator = BookieResources.createAllocator(baseConf);
 
     private boolean isAutoRecoveryEnabled;
+
+    private final List<Integer> bookiePorts = new ArrayList<>();
 
     SynchronousQueue<Throwable> asyncExceptions = new SynchronousQueue<>();
     protected void captureThrowable(Runnable c) {
@@ -282,6 +285,7 @@ public abstract class BookKeeperClusterTestCase {
             t.shutdown();
         }
         servers.clear();
+        bookiePorts.removeIf(PortManager::releaseLockedPort);
     }
 
     protected ServerConfiguration newServerConfiguration() throws Exception {
@@ -289,7 +293,7 @@ public abstract class BookKeeperClusterTestCase {
 
         int port;
         if (baseConf.isEnableLocalTransport() || !baseConf.getAllowEphemeralPorts()) {
-            port = PortManager.nextFreePort();
+            port = nextLockedFreePort();
         } else {
             port = 0;
         }

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/DirectProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/DirectProxyHandler.java
@@ -243,11 +243,11 @@ public class DirectProxyHandler {
                     .addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
         } else {
             if (inboundChannel.remoteAddress() instanceof InetSocketAddress
-                    && outboundChannel.localAddress() instanceof InetSocketAddress) {
+                    && inboundChannel.localAddress() instanceof InetSocketAddress) {
                 InetSocketAddress clientAddress = (InetSocketAddress) inboundChannel.remoteAddress();
                 String sourceAddress = clientAddress.getAddress().getHostAddress();
                 int sourcePort = clientAddress.getPort();
-                InetSocketAddress proxyAddress = (InetSocketAddress) inboundChannel.remoteAddress();
+                InetSocketAddress proxyAddress = (InetSocketAddress) inboundChannel.localAddress();
                 String destinationAddress = proxyAddress.getAddress().getHostAddress();
                 int destinationPort = proxyAddress.getPort();
                 HAProxyMessage msg = new HAProxyMessage(HAProxyProtocolVersion.V1, HAProxyCommand.PROXY,

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/extensions/SimpleProxyExtensionTestBase.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/extensions/SimpleProxyExtensionTestBase.java
@@ -22,12 +22,12 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.*;
 import io.netty.channel.socket.SocketChannel;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.bookkeeper.util.PortManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.broker.authentication.AuthenticationService;
 import org.apache.pulsar.common.configuration.PulsarConfigurationLoader;
+import org.apache.pulsar.common.util.PortManager;
 import org.apache.pulsar.metadata.impl.ZKMetadataStore;
 import org.apache.pulsar.proxy.server.ProxyConfiguration;
 import org.apache.pulsar.proxy.server.ProxyService;
@@ -43,12 +43,15 @@ import java.net.Socket;
 import java.net.SocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
+import static org.apache.pulsar.common.util.PortManager.nextLockedFreePort;
 import static org.mockito.Mockito.doReturn;
 import static org.testng.Assert.assertEquals;
 
@@ -59,6 +62,8 @@ public abstract class SimpleProxyExtensionTestBase extends MockedPulsarServiceBa
     public static final class MyProxyExtension implements ProxyExtension {
 
         private ProxyConfiguration conf;
+
+        private final List<Integer> ports = new ArrayList<>();
 
         @Override
         public String extensionName() {
@@ -81,7 +86,9 @@ public abstract class SimpleProxyExtensionTestBase extends MockedPulsarServiceBa
 
         @Override
         public Map<InetSocketAddress, ChannelInitializer<SocketChannel>> newChannelInitializers() {
-            return Collections.singletonMap(new InetSocketAddress(conf.getBindAddress(), PortManager.nextFreePort()),
+            int port = nextLockedFreePort();
+            this.ports.add(port);
+            return Collections.singletonMap(new InetSocketAddress(conf.getBindAddress(), port),
                     new ChannelInitializer<SocketChannel>() {
                 @Override
                 protected void initChannel(SocketChannel socketChannel) throws Exception {
@@ -106,7 +113,7 @@ public abstract class SimpleProxyExtensionTestBase extends MockedPulsarServiceBa
 
         @Override
         public void close() {
-
+            ports.removeIf(PortManager::releaseLockedPort);
         }
     }
 

--- a/site2/docs/cookbooks-retention-expiry.md
+++ b/site2/docs/cookbooks-retention-expiry.md
@@ -58,7 +58,7 @@ When a retention limit on a topic is exceeded, the oldest message is marked for 
 
 ### Defaults
 
-You can set message retention at instance level with the following two parameters: `defaultRetentionTimeInMinutes` and `defaultRetentionSizeInMB`. Both parameters are set to `0` by default. 
+You can set message retention at instance level with the following two parameters: `defaultRetentionTimeInMinutes` and `defaultRetentionSizeInMB`. By default, both parameters are set to `0`, which means disabling message retention.
 
 For more information on the two parameters, refer to the [`broker.conf`](reference-configuration.md#broker) configuration file.
 

--- a/site2/docs/security-overview.md
+++ b/site2/docs/security-overview.md
@@ -7,13 +7,13 @@ sidebar_label: "Overview"
 As the central message bus for a business, Apache Pulsar is frequently used for storing mission-critical data. Therefore, enabling security features in Pulsar is crucial. This chapter describes the main security controls that Pulsar uses to help protect your data.
 
 Pulsar security is based on the following core pillars.
-* [Encryption](#encryption)
-* [Authentication](#authentication)
-* [Authorization](#authorization)
+- [Encryption](#encryption)
+- [Authentication](#authentication)
+- [Authorization](#authorization)
 
 By default, Pulsar configures no encryption, authentication, or authorization. Any clients can communicate to Pulsar via plain text service URLs. So you must ensure that Pulsar accessing via these plain text service URLs is restricted to trusted clients only. In such cases, you can use network segmentation and/or authorization ACLs to restrict access to trusted IPs. If you use neither, the state of the cluster is wide open and anyone can access the cluster.
 
-Apache Pulsar uses an [Authentication Provider](#authentication) or an [Authentication Provider Chain](security-extending.md/#proxybroker-authentication-plugin) to establish the identity of a client and then assign a *role token* (a string like `admin` or `app1`)to that client. This role token can represent a single client or multiple clients and is then used for [Authorization](security-authorization.md) to determine what the client is authorized to do. You can use roles to control permission for clients to produce or consume from certain topics, administer the configuration for tenants, and so on.
+Apache Pulsar uses an [Authentication Provider](#authentication) or an [Authentication Provider Chain](security-extending.md/#proxybroker-authentication-plugin) to establish the identity of a client and then assign a *role token* (a string like `admin` or `app1`) to that client. This role token can represent a single client or multiple clients and is then used for [Authorization](security-authorization.md) to determine what the client is authorized to do. You can use roles to control permission for clients to produce or consume from certain topics, administer the configuration for tenants, and so on.
 
 ## Encryption
 

--- a/site2/website/versioned_docs/version-2.1.0-incubating/security-overview.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/security-overview.md
@@ -21,7 +21,7 @@ It is strongly recommended to secure the service components in your Apache Pulsa
 In Pulsar, a *role* is a string, like `admin` or `app1`, that can represent a single client or multiple clients. Roles are used to control permission for clients
 to produce or consume from certain topics, administer the configuration for tenants, and more.
 
-Apache Pulsar uses a [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign that client a *role token*. This
+Apache Pulsar uses an [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign that client a *role token*. This
 role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
 
 ## Authentication Providers

--- a/site2/website/versioned_docs/version-2.1.1-incubating/security-overview.md
+++ b/site2/website/versioned_docs/version-2.1.1-incubating/security-overview.md
@@ -20,7 +20,7 @@ You had better secure the service components in your Apache Pulsar deployment.
 
 In Pulsar, a *role* is a string, like `admin` or `app1`, which can represent a single client or multiple clients. You can use roles to control permission for clients to produce or consume from certain topics, administer the configuration for tenants, and so on.
 
-Apache Pulsar uses a [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
+Apache Pulsar uses an [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
 
 ## Authentication providers
 

--- a/site2/website/versioned_docs/version-2.10.0-deprecated/security-overview.md
+++ b/site2/website/versioned_docs/version-2.10.0-deprecated/security-overview.md
@@ -21,7 +21,7 @@ You had better secure the service components in your Apache Pulsar deployment.
 
 In Pulsar, a *role* is a string, like `admin` or `app1`, which can represent a single client or multiple clients. You can use roles to control permission for clients to produce or consume from certain topics, administer the configuration for tenants, and so on.
 
-Apache Pulsar uses a [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
+Apache Pulsar uses an [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
 
 ## Authentication providers
 

--- a/site2/website/versioned_docs/version-2.10.1-deprecated/security-overview.md
+++ b/site2/website/versioned_docs/version-2.10.1-deprecated/security-overview.md
@@ -21,7 +21,7 @@ You had better secure the service components in your Apache Pulsar deployment.
 
 In Pulsar, a *role* is a string, like `admin` or `app1`, which can represent a single client or multiple clients. You can use roles to control permission for clients to produce or consume from certain topics, administer the configuration for tenants, and so on.
 
-Apache Pulsar uses a [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
+Apache Pulsar uses an [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
 
 ## Authentication providers
 

--- a/site2/website/versioned_docs/version-2.10.x/security-overview.md
+++ b/site2/website/versioned_docs/version-2.10.x/security-overview.md
@@ -21,7 +21,7 @@ You had better secure the service components in your Apache Pulsar deployment.
 
 In Pulsar, a *role* is a string, like `admin` or `app1`, which can represent a single client or multiple clients. You can use roles to control permission for clients to produce or consume from certain topics, administer the configuration for tenants, and so on.
 
-Apache Pulsar uses a [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
+Apache Pulsar uses an [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
 
 ## Authentication providers
 

--- a/site2/website/versioned_docs/version-2.2.0/security-overview.md
+++ b/site2/website/versioned_docs/version-2.2.0/security-overview.md
@@ -20,7 +20,7 @@ You had better secure the service components in your Apache Pulsar deployment.
 
 In Pulsar, a *role* is a string, like `admin` or `app1`, which can represent a single client or multiple clients. You can use roles to control permission for clients to produce or consume from certain topics, administer the configuration for tenants, and so on.
 
-Apache Pulsar uses a [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
+Apache Pulsar uses an [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
 
 ## Authentication providers
 

--- a/site2/website/versioned_docs/version-2.2.1/security-overview.md
+++ b/site2/website/versioned_docs/version-2.2.1/security-overview.md
@@ -20,7 +20,7 @@ You had better secure the service components in your Apache Pulsar deployment.
 
 In Pulsar, a *role* is a string, like `admin` or `app1`, which can represent a single client or multiple clients. You can use roles to control permission for clients to produce or consume from certain topics, administer the configuration for tenants, and so on.
 
-Apache Pulsar uses a [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
+Apache Pulsar uses an [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
 
 ## Authentication providers
 

--- a/site2/website/versioned_docs/version-2.3.0/security-overview.md
+++ b/site2/website/versioned_docs/version-2.3.0/security-overview.md
@@ -20,7 +20,7 @@ You had better secure the service components in your Apache Pulsar deployment.
 
 In Pulsar, a *role* is a string, like `admin` or `app1`, which can represent a single client or multiple clients. You can use roles to control permission for clients to produce or consume from certain topics, administer the configuration for tenants, and so on.
 
-Apache Pulsar uses a [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
+Apache Pulsar uses an [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
 
 ## Authentication providers
 

--- a/site2/website/versioned_docs/version-2.3.1/security-overview.md
+++ b/site2/website/versioned_docs/version-2.3.1/security-overview.md
@@ -20,7 +20,7 @@ You had better secure the service components in your Apache Pulsar deployment.
 
 In Pulsar, a *role* is a string, like `admin` or `app1`, which can represent a single client or multiple clients. You can use roles to control permission for clients to produce or consume from certain topics, administer the configuration for tenants, and so on.
 
-Apache Pulsar uses a [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
+Apache Pulsar uses an [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
 
 ## Authentication providers
 

--- a/site2/website/versioned_docs/version-2.3.2/security-overview.md
+++ b/site2/website/versioned_docs/version-2.3.2/security-overview.md
@@ -21,7 +21,7 @@ It is strongly recommended to secure the service components in your Apache Pulsa
 In Pulsar, a *role* is a string, like `admin` or `app1`, that can represent a single client or multiple clients. Roles are used to control permission for clients
 to produce or consume from certain topics, administer the configuration for tenants, and more.
 
-Apache Pulsar uses a [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign that client a *role token*. This
+Apache Pulsar uses an [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign that client a *role token*. This
 role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
 
 ## Authentication Providers

--- a/site2/website/versioned_docs/version-2.5.0/security-overview.md
+++ b/site2/website/versioned_docs/version-2.5.0/security-overview.md
@@ -17,7 +17,7 @@ You had better secure the service components in your Apache Pulsar deployment.
 
 In Pulsar, a *role* is a string, like `admin` or `app1`, which can represent a single client or multiple clients. You can use roles to control permission for clients to produce or consume from certain topics, administer the configuration for tenants, and so on.
 
-Apache Pulsar uses a [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
+Apache Pulsar uses an [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
 
 ## Authentication providers
 

--- a/site2/website/versioned_docs/version-2.5.1/security-overview.md
+++ b/site2/website/versioned_docs/version-2.5.1/security-overview.md
@@ -20,7 +20,7 @@ You had better secure the service components in your Apache Pulsar deployment.
 
 In Pulsar, a *role* is a string, like `admin` or `app1`, which can represent a single client or multiple clients. You can use roles to control permission for clients to produce or consume from certain topics, administer the configuration for tenants, and so on.
 
-Apache Pulsar uses a [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
+Apache Pulsar uses an [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
 
 ## Authentication providers
 

--- a/site2/website/versioned_docs/version-2.5.2/security-overview.md
+++ b/site2/website/versioned_docs/version-2.5.2/security-overview.md
@@ -20,7 +20,7 @@ You had better secure the service components in your Apache Pulsar deployment.
 
 In Pulsar, a *role* is a string, like `admin` or `app1`, which can represent a single client or multiple clients. You can use roles to control permission for clients to produce or consume from certain topics, administer the configuration for tenants, and so on.
 
-Apache Pulsar uses a [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
+Apache Pulsar uses an [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
 
 ## Authentication providers
 

--- a/site2/website/versioned_docs/version-2.6.0/security-overview.md
+++ b/site2/website/versioned_docs/version-2.6.0/security-overview.md
@@ -17,7 +17,7 @@ You had better secure the service components in your Apache Pulsar deployment.
 
 In Pulsar, a *role* is a string, like `admin` or `app1`, which can represent a single client or multiple clients. You can use roles to control permission for clients to produce or consume from certain topics, administer the configuration for tenants, and so on.
 
-Apache Pulsar uses a [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
+Apache Pulsar uses an [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
 
 ## Authentication providers
 

--- a/site2/website/versioned_docs/version-2.6.1/security-overview.md
+++ b/site2/website/versioned_docs/version-2.6.1/security-overview.md
@@ -21,7 +21,7 @@ You had better secure the service components in your Apache Pulsar deployment.
 
 In Pulsar, a *role* is a string, like `admin` or `app1`, which can represent a single client or multiple clients. You can use roles to control permission for clients to produce or consume from certain topics, administer the configuration for tenants, and so on.
 
-Apache Pulsar uses a [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
+Apache Pulsar uses an [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
 
 ## Authentication providers
 

--- a/site2/website/versioned_docs/version-2.6.2/security-overview.md
+++ b/site2/website/versioned_docs/version-2.6.2/security-overview.md
@@ -21,7 +21,7 @@ You had better secure the service components in your Apache Pulsar deployment.
 
 In Pulsar, a *role* is a string, like `admin` or `app1`, which can represent a single client or multiple clients. You can use roles to control permission for clients to produce or consume from certain topics, administer the configuration for tenants, and so on.
 
-Apache Pulsar uses a [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
+Apache Pulsar uses an [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
 
 ## Authentication providers
 

--- a/site2/website/versioned_docs/version-2.6.3/security-overview.md
+++ b/site2/website/versioned_docs/version-2.6.3/security-overview.md
@@ -21,7 +21,7 @@ You had better secure the service components in your Apache Pulsar deployment.
 
 In Pulsar, a *role* is a string, like `admin` or `app1`, which can represent a single client or multiple clients. You can use roles to control permission for clients to produce or consume from certain topics, administer the configuration for tenants, and so on.
 
-Apache Pulsar uses a [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
+Apache Pulsar uses an [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
 
 ## Authentication providers
 

--- a/site2/website/versioned_docs/version-2.6.4/security-overview.md
+++ b/site2/website/versioned_docs/version-2.6.4/security-overview.md
@@ -21,7 +21,7 @@ You had better secure the service components in your Apache Pulsar deployment.
 
 In Pulsar, a *role* is a string, like `admin` or `app1`, which can represent a single client or multiple clients. You can use roles to control permission for clients to produce or consume from certain topics, administer the configuration for tenants, and so on.
 
-Apache Pulsar uses a [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
+Apache Pulsar uses an [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
 
 ## Authentication providers
 

--- a/site2/website/versioned_docs/version-2.7.0/security-overview.md
+++ b/site2/website/versioned_docs/version-2.7.0/security-overview.md
@@ -21,7 +21,7 @@ You had better secure the service components in your Apache Pulsar deployment.
 
 In Pulsar, a *role* is a string, like `admin` or `app1`, which can represent a single client or multiple clients. You can use roles to control permission for clients to produce or consume from certain topics, administer the configuration for tenants, and so on.
 
-Apache Pulsar uses a [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
+Apache Pulsar uses an [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
 
 ## Authentication providers
 

--- a/site2/website/versioned_docs/version-2.7.1/security-overview.md
+++ b/site2/website/versioned_docs/version-2.7.1/security-overview.md
@@ -21,7 +21,7 @@ You had better secure the service components in your Apache Pulsar deployment.
 
 In Pulsar, a *role* is a string, like `admin` or `app1`, which can represent a single client or multiple clients. You can use roles to control permission for clients to produce or consume from certain topics, administer the configuration for tenants, and so on.
 
-Apache Pulsar uses a [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
+Apache Pulsar uses an [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
 
 ## Authentication providers
 

--- a/site2/website/versioned_docs/version-2.7.2/security-overview.md
+++ b/site2/website/versioned_docs/version-2.7.2/security-overview.md
@@ -21,7 +21,7 @@ You had better secure the service components in your Apache Pulsar deployment.
 
 In Pulsar, a *role* is a string, like `admin` or `app1`, which can represent a single client or multiple clients. You can use roles to control permission for clients to produce or consume from certain topics, administer the configuration for tenants, and so on.
 
-Apache Pulsar uses a [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
+Apache Pulsar uses an [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
 
 ## Authentication providers
 

--- a/site2/website/versioned_docs/version-2.7.3/security-overview.md
+++ b/site2/website/versioned_docs/version-2.7.3/security-overview.md
@@ -21,7 +21,7 @@ You had better secure the service components in your Apache Pulsar deployment.
 
 In Pulsar, a *role* is a string, like `admin` or `app1`, which can represent a single client or multiple clients. You can use roles to control permission for clients to produce or consume from certain topics, administer the configuration for tenants, and so on.
 
-Apache Pulsar uses a [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
+Apache Pulsar uses an [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
 
 ## Authentication providers
 

--- a/site2/website/versioned_docs/version-2.7.4/security-overview.md
+++ b/site2/website/versioned_docs/version-2.7.4/security-overview.md
@@ -21,7 +21,7 @@ You had better secure the service components in your Apache Pulsar deployment.
 
 In Pulsar, a *role* is a string, like `admin` or `app1`, which can represent a single client or multiple clients. You can use roles to control permission for clients to produce or consume from certain topics, administer the configuration for tenants, and so on.
 
-Apache Pulsar uses a [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
+Apache Pulsar uses an [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
 
 ## Authentication providers
 

--- a/site2/website/versioned_docs/version-2.7.5/security-overview.md
+++ b/site2/website/versioned_docs/version-2.7.5/security-overview.md
@@ -21,7 +21,7 @@ You had better secure the service components in your Apache Pulsar deployment.
 
 In Pulsar, a *role* is a string, like `admin` or `app1`, which can represent a single client or multiple clients. You can use roles to control permission for clients to produce or consume from certain topics, administer the configuration for tenants, and so on.
 
-Apache Pulsar uses a [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
+Apache Pulsar uses an [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
 
 ## Authentication providers
 

--- a/site2/website/versioned_docs/version-2.8.0-deprecated/security-overview.md
+++ b/site2/website/versioned_docs/version-2.8.0-deprecated/security-overview.md
@@ -21,7 +21,7 @@ You had better secure the service components in your Apache Pulsar deployment.
 
 In Pulsar, a *role* is a string, like `admin` or `app1`, which can represent a single client or multiple clients. You can use roles to control permission for clients to produce or consume from certain topics, administer the configuration for tenants, and so on.
 
-Apache Pulsar uses a [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
+Apache Pulsar uses an [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
 
 ## Authentication providers
 

--- a/site2/website/versioned_docs/version-2.8.1-deprecated/security-overview.md
+++ b/site2/website/versioned_docs/version-2.8.1-deprecated/security-overview.md
@@ -21,7 +21,7 @@ You had better secure the service components in your Apache Pulsar deployment.
 
 In Pulsar, a *role* is a string, like `admin` or `app1`, which can represent a single client or multiple clients. You can use roles to control permission for clients to produce or consume from certain topics, administer the configuration for tenants, and so on.
 
-Apache Pulsar uses a [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
+Apache Pulsar uses an [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
 
 ## Authentication providers
 

--- a/site2/website/versioned_docs/version-2.8.2-deprecated/security-overview.md
+++ b/site2/website/versioned_docs/version-2.8.2-deprecated/security-overview.md
@@ -21,7 +21,7 @@ You had better secure the service components in your Apache Pulsar deployment.
 
 In Pulsar, a *role* is a string, like `admin` or `app1`, which can represent a single client or multiple clients. You can use roles to control permission for clients to produce or consume from certain topics, administer the configuration for tenants, and so on.
 
-Apache Pulsar uses a [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
+Apache Pulsar uses an [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
 
 ## Authentication providers
 

--- a/site2/website/versioned_docs/version-2.8.3-deprecated/security-overview.md
+++ b/site2/website/versioned_docs/version-2.8.3-deprecated/security-overview.md
@@ -21,7 +21,7 @@ You had better secure the service components in your Apache Pulsar deployment.
 
 In Pulsar, a *role* is a string, like `admin` or `app1`, which can represent a single client or multiple clients. You can use roles to control permission for clients to produce or consume from certain topics, administer the configuration for tenants, and so on.
 
-Apache Pulsar uses a [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
+Apache Pulsar uses an [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
 
 ## Authentication providers
 

--- a/site2/website/versioned_docs/version-2.8.x/security-overview.md
+++ b/site2/website/versioned_docs/version-2.8.x/security-overview.md
@@ -21,7 +21,7 @@ You had better secure the service components in your Apache Pulsar deployment.
 
 In Pulsar, a *role* is a string, like `admin` or `app1`, which can represent a single client or multiple clients. You can use roles to control permission for clients to produce or consume from certain topics, administer the configuration for tenants, and so on.
 
-Apache Pulsar uses a [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
+Apache Pulsar uses an [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
 
 ## Authentication providers
 

--- a/site2/website/versioned_docs/version-2.9.0-deprecated/security-overview.md
+++ b/site2/website/versioned_docs/version-2.9.0-deprecated/security-overview.md
@@ -21,7 +21,7 @@ You had better secure the service components in your Apache Pulsar deployment.
 
 In Pulsar, a *role* is a string, like `admin` or `app1`, which can represent a single client or multiple clients. You can use roles to control permission for clients to produce or consume from certain topics, administer the configuration for tenants, and so on.
 
-Apache Pulsar uses a [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
+Apache Pulsar uses an [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
 
 ## Authentication providers
 

--- a/site2/website/versioned_docs/version-2.9.1-deprecated/security-overview.md
+++ b/site2/website/versioned_docs/version-2.9.1-deprecated/security-overview.md
@@ -21,7 +21,7 @@ You had better secure the service components in your Apache Pulsar deployment.
 
 In Pulsar, a *role* is a string, like `admin` or `app1`, which can represent a single client or multiple clients. You can use roles to control permission for clients to produce or consume from certain topics, administer the configuration for tenants, and so on.
 
-Apache Pulsar uses a [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
+Apache Pulsar uses an [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
 
 ## Authentication providers
 

--- a/site2/website/versioned_docs/version-2.9.2-deprecated/security-overview.md
+++ b/site2/website/versioned_docs/version-2.9.2-deprecated/security-overview.md
@@ -21,7 +21,7 @@ You had better secure the service components in your Apache Pulsar deployment.
 
 In Pulsar, a *role* is a string, like `admin` or `app1`, which can represent a single client or multiple clients. You can use roles to control permission for clients to produce or consume from certain topics, administer the configuration for tenants, and so on.
 
-Apache Pulsar uses a [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
+Apache Pulsar uses an [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
 
 ## Authentication providers
 

--- a/site2/website/versioned_docs/version-2.9.3-deprecated/security-overview.md
+++ b/site2/website/versioned_docs/version-2.9.3-deprecated/security-overview.md
@@ -21,7 +21,7 @@ You had better secure the service components in your Apache Pulsar deployment.
 
 In Pulsar, a *role* is a string, like `admin` or `app1`, which can represent a single client or multiple clients. You can use roles to control permission for clients to produce or consume from certain topics, administer the configuration for tenants, and so on.
 
-Apache Pulsar uses a [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
+Apache Pulsar uses an [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
 
 ## Authentication providers
 

--- a/site2/website/versioned_docs/version-2.9.x/security-overview.md
+++ b/site2/website/versioned_docs/version-2.9.x/security-overview.md
@@ -21,7 +21,7 @@ You had better secure the service components in your Apache Pulsar deployment.
 
 In Pulsar, a *role* is a string, like `admin` or `app1`, which can represent a single client or multiple clients. You can use roles to control permission for clients to produce or consume from certain topics, administer the configuration for tenants, and so on.
 
-Apache Pulsar uses a [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
+Apache Pulsar uses an [Authentication Provider](#authentication-providers) to establish the identity of a client and then assign a *role token* to that client. This role token is then used for [Authorization and ACLs](security-authorization.md) to determine what the client is authorized to do.
 
 ## Authentication providers
 

--- a/wiki/release/release-note-guide.md
+++ b/wiki/release/release-note-guide.md
@@ -41,9 +41,17 @@ For the [Pulsar Release Note page](https://pulsar.apache.org/release-notes/):
 
 ## Submit release notes
 
-Follow the steps below to submit release notes for Pulsar and clients.
+Follow the steps below to submit release notes for Pulsar and clients (**Java and WebSocket**).
 
-1. On the [Pulsar Releases Page - GitHub](https://github.com/apache/pulsar/releases), add a release note for the new release.
+> **Note**
+>
+> For **C++, Python, Go, Node.js, and C#**, you do not need to take care of them since their release notes are synced from their repos to the [Pulsar Release Note page](https://pulsar.apache.org/release-notes).
+
+1. Submit a PR to add **separate** release notes for Pulsar and clients (**Java and WebSocket**) to [pulsar-site/site2/website-next/release-notes/versioned/](https://github.com/apache/pulsar-site/tree/main/site2/website-next/release-notes/versioned). 
+
+    Get this PR reviewed and merged.
+
+2. Copy the release note to the [Pulsar Releases Page - GitHub](https://github.com/apache/pulsar/releases).
 
     <table>
     <thead>
@@ -55,20 +63,16 @@ Follow the steps below to submit release notes for Pulsar and clients.
     <tbody>
       <tr>
         <td colspan="2">Pulsar core</td>
-        <td>Add a release note for it.</td>
+        <td>Copy the release note content.</td>
       </tr>
       <tr>
         <td rowspan="2">Pulsar clients</td>
-        <td> - Java<br><br> - WebSocket<br><br> - C++<br><br> - Python</td>
-        <td>Add separate release notes for them, that is, create independent sections in the release note.<br><br>Example<br><br><img title="Java client release note example" alt="Java client release note example" src="../assets/release-note-guide-1.png"></td>
-      </tr>
-      <tr>
-        <td> - Go<br><br> - Node.js<br><br> - C#</td>
-        <td>No action is needed. You do not need to take care of them since their release notes are synced from their repos to the <a href="https://pulsar.apache.org/release-notes/">Pulsar Release Note page</a>.</td>
+        <td> - Java<br><br> - WebSocket <br><br> 
+        <td>Create independent sections for each client and copy release note content.<br><br>Example<br><br><img title="Java client release note example" alt="Java client release note example" src="../assets/release-note-guide-1.png"></td>
       </tr>
     </tbody>
     </table>
 
     After the new release is published, all the information about the release is automatically added to the [Pulsar Release Note page](https://pulsar.apache.org/release-notes/).
 
-2. Check whether the release information is shown on the [Pulsar Release Note page](https://pulsar.apache.org/release-notes/) after the website is updated and built successfully.
+3. Check whether the release information is shown on the [Pulsar Release Note page](https://pulsar.apache.org/release-notes/) after the website is updated and built successfully.


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

### Motivation

Improve functions worker bootstrap time with increased number of connectors. Currently all nar files are unpacked during startup to perform validation steps (e.g. if the connector class implements the correct interfaces). For that, the NarClassLoader will unpack all nars to disk sequentially which could delay startup.

On my Machine (Mac M1) I observed an improvement of ~ 3X (from 48 seconds down to 15 seconds). I know the max number of chosen threads (4) is a magic number (I have not seen improvements beyond that number), but if this is the right approach and it is worth it, we can make this number configurable (need guidance on the right config place)

Sample output:
```
2022-09-30T01:22:13,778+0000 [main] INFO  org.apache.pulsar.functions.utils.io.ConnectorUtils - Searching for connectors in /pulsar/./connectors
2022-09-30T01:22:13,779+0000 [main] INFO  org.apache.pulsar.functions.utils.io.ConnectorUtils - Loading 58 connector definitions with a thread pool of size 4
2022-09-30T01:22:13,781+0000 [search-connectors-executor-0] INFO  org.apache.pulsar.common.nar.NarUnpacker - Created directory /tmp/pulsar-nar/pulsar-io-debezium-mssql-2.10.1.8-SNAPSHOT.nar-unpacked
2022-09-30T01:22:13,781+0000 [search-connectors-executor-1] INFO  org.apache.pulsar.common.nar.NarUnpacker - Created directory /tmp/pulsar-nar/pulsar-snowflake-connector-0.1.10.nar-unpacked
2022-09-30T01:22:13,781+0000 [search-connectors-executor-2] INFO  org.apache.pulsar.common.nar.NarUnpacker - Created directory /tmp/pulsar-nar/pulsar-io-mongo-2.10.1.8-SNAPSHOT.nar-unpacked
2022-09-30T01:22:13,784+0000 [search-connectors-executor-3] INFO  org.apache.pulsar.common.nar.NarUnpacker - Created directory /tmp/pulsar-nar/pulsar-io-kinesis-2.10.1.8-SNAPSHOT.nar-unpacked
2022-09-30T01:22:13,895+0000 [search-connectors-executor-2] INFO  org.apache.pulsar.common.nar.NarUnpacker - Extracting /pulsar/./connectors/pulsar-io-mongo-2.10.1.8-SNAPSHOT.nar to /tmp/pulsar-nar/pulsar-io-mongo-2.10.1.8-SNAPSHOT.nar-unpacked/gs7wF7XmmgT1MjvpwSxFfA
```

### Modifications

Just run the connectors search function (which unpacks the nars) in parallel via a CachedThreadPool.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as the unit tests under PulsarFunctionLocalRunTest already covers this path. Also CI for each existing connector will cover the change

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

### Matching PR in forked repository

PR in forked repository: (https://github.com/aymkhalil/pulsar/pull/2)

After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.

-->
