### PR TITLE
[improve] Refresh ns policy when deciding auto topic creation eligibility 

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
@@ -122,7 +122,15 @@ public class NamespaceResources extends BaseResources<Policies> {
     }
 
     public CompletableFuture<Optional<Policies>> getPoliciesAsync(NamespaceName ns) {
-        return getCache().get(joinPath(BASE_POLICIES_PATH, ns.toString()));
+        return getPoliciesAsync(ns, false);
+    }
+
+    public CompletableFuture<Optional<Policies>> getPoliciesAsync(NamespaceName ns, boolean refresh) {
+        if (refresh) {
+            return refreshAndGetAsync(joinPath(BASE_POLICIES_PATH, ns.toString()));
+        } else {
+            return getAsync(joinPath(BASE_POLICIES_PATH, ns.toString()));
+        }
     }
 
     public void setPolicies(NamespaceName ns, Function<Policies, Policies> function) throws MetadataStoreException {

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/resources/NamespaceResourcesTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/resources/NamespaceResourcesTest.java
@@ -20,15 +20,45 @@ package org.apache.pulsar.broker.resources;
 
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
+import java.util.concurrent.CompletableFuture;
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.policies.data.Policies;
+import org.apache.pulsar.metadata.api.MetadataCache;
+import org.apache.pulsar.metadata.api.MetadataStore;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 
 public class NamespaceResourcesTest {
+
+    private MetadataStore mockMetadataStore;
+    private NamespaceResources namespaceResources;
+
+    @BeforeMethod
+    public void setUp() {
+        mockMetadataStore = Mockito.mock(MetadataStore.class);
+        Mockito.doReturn(Mockito.mock(MetadataCache.class)).when(mockMetadataStore).getMetadataCache(Policies.class);
+        Mockito.doReturn(CompletableFuture.completedFuture(null)).when(mockMetadataStore).sync(Mockito.anyString());
+        namespaceResources = new NamespaceResources(mockMetadataStore, 0);
+    }
     @Test
     public void test_pathIsFromNamespace() {
         assertFalse(NamespaceResources.pathIsFromNamespace("/admin/clusters"));
         assertFalse(NamespaceResources.pathIsFromNamespace("/admin/policies"));
         assertFalse(NamespaceResources.pathIsFromNamespace("/admin/policies/my-tenant"));
         assertTrue(NamespaceResources.pathIsFromNamespace("/admin/policies/my-tenant/my-ns"));
+    }
+
+    @Test
+    public void testGetPolicesAsync() {
+        namespaceResources.getPoliciesAsync(NamespaceName.get("public/default"));
+        Mockito.verify(mockMetadataStore, Mockito.never()).sync(Mockito.anyString());
+    }
+
+    @Test
+    public void testGetPolicesAsyncAndRefresh() {
+        namespaceResources.getPoliciesAsync(NamespaceName.get("public/default"), true);
+        Mockito.verify(mockMetadataStore, Mockito.times(1)).sync("/admin/policies/public/default");
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -490,7 +490,7 @@ public abstract class AdminResource extends PulsarWebResource {
                 .thenCompose(__ -> {
                     if (checkAllowAutoCreation) {
                         return pulsar().getBrokerService()
-                                .fetchPartitionedTopicMetadataCheckAllowAutoCreationAsync(topicName);
+                                .fetchPartitionedTopicMetadataCheckAllowAutoCreationAsync(topicName, true);
                     } else {
                         return pulsar().getBrokerService().fetchPartitionedTopicMetadataAsync(topicName);
                     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -72,7 +72,7 @@ public class TopicLookupBase extends PulsarWebResource {
                             ? CompletableFuture.completedFuture(true)
                             : pulsar().getNamespaceService().checkTopicExists(topicName)
                                 .thenCompose(exists -> exists ? CompletableFuture.completedFuture(true)
-                                        : pulsar().getBrokerService().isAllowAutoTopicCreationAsync(topicName));
+                                        : pulsar().getBrokerService().isAllowAutoTopicCreationAsync(topicName, true));
 
                     return existFuture;
                 })

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/lookup/http/HttpTopicLookupv2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/lookup/http/HttpTopicLookupv2Test.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.lookup.http;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -105,7 +106,7 @@ public class HttpTopicLookupv2Test {
         doReturn(auth).when(brokerService).getAuthorizationService();
         doReturn(new Semaphore(1000)).when(brokerService).getLookupRequestSemaphore();
         doReturn(CompletableFuture.completedFuture(false)).when(brokerService)
-                .isAllowAutoTopicCreationAsync(any(TopicName.class), true);
+                .isAllowAutoTopicCreationAsync(any(TopicName.class), eq(true));
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/lookup/http/HttpTopicLookupv2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/lookup/http/HttpTopicLookupv2Test.java
@@ -105,7 +105,7 @@ public class HttpTopicLookupv2Test {
         doReturn(auth).when(brokerService).getAuthorizationService();
         doReturn(new Semaphore(1000)).when(brokerService).getLookupRequestSemaphore();
         doReturn(CompletableFuture.completedFuture(false)).when(brokerService)
-                .isAllowAutoTopicCreationAsync(any(TopicName.class));
+                .isAllowAutoTopicCreationAsync(any(TopicName.class), true);
     }
 
     @Test


### PR DESCRIPTION
Continuation of https://github.com/apache/pulsar/pull/18518 and https://github.com/apache/pulsar/pull/17609 to ensure the ns policy deleted is in consistent state between brokers when performing and isAllowAutoTopicCreationAsync